### PR TITLE
Feature/mapping team user

### DIFF
--- a/src/main/java/maestrogroup/core/mapping/MappingController.java
+++ b/src/main/java/maestrogroup/core/mapping/MappingController.java
@@ -1,4 +1,65 @@
 package maestrogroup.core.mapping;
 
+import maestrogroup.core.team.model.PostTeamReq;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+
+@RequestMapping("/mapping")
+@RestController
 public class MappingController {
+    @Autowired
+    private final MappingService mappingService;
+    @Autowired
+    private final MappingProvider mappingProvider;
+    @Autowired
+    private final MappingDao mappingDao;
+
+    public MappingController(MappingService mappingService, MappingProvider mappingProvider, MappingDao mappingDao){
+        this.mappingService = mappingService;
+        this.mappingProvider = mappingProvider;
+        this.mappingDao = mappingDao;
+    }
+
+
+    // 최초로 팀 그룹 생성하기 => 현재 로그인한 유저가 자동으로 팀 그룹에 속하도록 추가적인 API 개발 요망
+    // 즉, Team 객체가 생성됨과 동시에 Mapping 객체도 생성되어서 해당 Team 과 User 를 매핑 시켜줘야함
+    // 지금 API 에서는 일단 userIdx 로 임의의 실험을 위해 로그인한 유저의 pk 값을 받아오도록 함. 나중에 꼭 수정하자!
+
+    // team 객체와 mapping 객체를 생성
+    @ResponseBody
+    @PostMapping("makeTeam/{userIdx}")
+    public void makeTeam(@PathVariable("userIdx") int userIdx, @RequestBody PostTeamReq postTeamReq){
+        System.out.println(userIdx);
+        System.out.println(postTeamReq.getTeamName());
+        System.out.println(postTeamReq.getTeamImgUrl());
+        mappingService.makeTeam(userIdx, postTeamReq);
+    }
+    /*
+    @ResponseBody
+    @PostMapping("/create_team")
+    public void createTeam(@RequestBody PostTeamReq postTeamReq){
+        teamService.createTeam(postTeamReq);
+        //PostTeamRes postTeamRes = teamService.createTeam(postTeamReq);
+        //return postTeamRes;
+    }
+     */
+
+    // 이전에 생성된 팀원 그룹에 특정 유저를 초대하기 : mapping 객체만 생성함
+    @PostMapping("/inviteUser/{teamIdx}/{userIdx}")
+    public void inviteUser(@PathVariable("teamIdx") int teamIdx, @PathVariable("userIdx") int userIdx){
+        mappingService.inviteUser(teamIdx, userIdx);
+    }
+
+
+    // 해당 그룹을 특정 유저가 탈퇴할떄 Mapping 객체가 삭제되도록 구현
+    // + 그리고 해당 그룹 팀의 총 인원수가 0명일떄, 그룹 객체(Team 객체)도 Mapping객체와 함께 삭제되도록 구현
+    @GetMapping("/getTeamMembers/{teamIdx}")
+    public void getTeamMembers(@PathVariable("teamIdx") int teamIdx){
+
+    }
 }
+
+
+
+

--- a/src/main/java/maestrogroup/core/mapping/MappingController.java
+++ b/src/main/java/maestrogroup/core/mapping/MappingController.java
@@ -1,8 +1,11 @@
 package maestrogroup.core.mapping;
 
 import maestrogroup.core.team.model.PostTeamReq;
+import maestrogroup.core.user.model.GetUser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 
 @RequestMapping("/mapping")
@@ -54,9 +57,15 @@ public class MappingController {
 
     // 해당 그룹을 특정 유저가 탈퇴할떄 Mapping 객체가 삭제되도록 구현
     // + 그리고 해당 그룹 팀의 총 인원수가 0명일떄, 그룹 객체(Team 객체)도 Mapping객체와 함께 삭제되도록 구현
-    @GetMapping("/getTeamMembers/{teamIdx}")
-    public void getTeamMembers(@PathVariable("teamIdx") int teamIdx){
+    @DeleteMapping("deleteTeam/{teamIdx}")
+    public void deleteTeam(@PathVariable("teamIdx") int teamIdx){
 
+    }
+
+    // 특정 팀 그룹에 속하는 모든 팀멤버 출력
+    @GetMapping("/getTeamMembers/{teamIdx}")
+    public List<GetUser> getTeamMembers(@PathVariable("teamIdx") int teamIdx){
+        return mappingProvider.getTeamMembers(teamIdx);
     }
 }
 

--- a/src/main/java/maestrogroup/core/mapping/MappingController.java
+++ b/src/main/java/maestrogroup/core/mapping/MappingController.java
@@ -62,12 +62,21 @@ public class MappingController {
 
     }
 
-    // 특정 팀 그룹에 속하는 모든 팀멤버 출력
+    // 특정 팀 그룹에 속하는 모든 팀멤버 출력 : ManyToMany
     @GetMapping("/getTeamMembers/{teamIdx}")
     public List<GetUser> getTeamMembers(@PathVariable("teamIdx") int teamIdx){
         return mappingProvider.getTeamMembers(teamIdx);
     }
+
+    // 특정 유저가 속해있는 모든 팀 그룹 출력 : ManyToMany
+    @GetMapping("/getTeamList/{userIdx}")
+    public List<GetUser> getTeamList(@PathVariable("userIdx") int userIdx){
+
+    }
 }
+
+
+
 
 
 

--- a/src/main/java/maestrogroup/core/mapping/MappingDao.java
+++ b/src/main/java/maestrogroup/core/mapping/MappingDao.java
@@ -1,12 +1,18 @@
 package maestrogroup.core.mapping;
 
+import maestrogroup.core.mapping.model.GetUserIdx;
 import maestrogroup.core.mapping.model.Mapping;
 import maestrogroup.core.team.model.PostTeamReq;
+import maestrogroup.core.user.model.GetUser;
+import org.apache.catalina.LifecycleState;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
+import java.util.ArrayList;
+
+import java.util.List;
 
 @Repository
 public class MappingDao {
@@ -36,16 +42,46 @@ public class MappingDao {
         Object[] createMappingParams = new Object[]{teamIdx, userIdx};
         this.jdbcTemplate.update(makeTeamQuery, createMappingParams); // Mapping 객체 생성
     }
-    /*
-    public void createTeam(PostTeamReq postTeamReq) {
-        String createTeamQuery = "insert into Team (teamName, teamImgUrl) VALUES (?, ?)";
-        Object[] createUserParams = new Object[]{postTeamReq.getTeamName(), postTeamReq.getTeamImgUrl()};
-        this.jdbcTemplate.update(createTeamQuery, createUserParams);
 
-        String lastInsertTeamIdx = "select last_insert_id()";
-        String insertTeamQuery = "select * from Team where teamIdx = ?";
+    // ManyToMany 다대다 관계 활용
+    public List<GetUser> getTeamMembers(int teamIdx){
+        String getTeamAllUserIdxQuery = "select userIdx from Mapping where teamIdx = ?"; // teamIdx 값에 속하는 팀에 속하는 유저들의 userIdx 값들을 추출
+
+        // userIdx 값들이 추출해서 userIdx값들이 저장된 GetUserIdx 리스트 생성
+        java.util.List<GetUserIdx> GetUserIdxList = this.jdbcTemplate.query(getTeamAllUserIdxQuery,
+                (rs, rowNum) -> new GetUserIdx(
+                        rs.getInt("userIdx")), teamIdx);
+
+        List<Integer> userIdxlist = new ArrayList<Integer>();
+        // 각 GetUserIdx 객체로부터 userIdx 값을 추출해서 int형 리스트 생성
+        for(GetUserIdx getUserIdx : GetUserIdxList){
+            userIdxlist.add(getUserIdx.getUserIdx());
+        }
+
+        // 반복문으로 순환하면서 얻어온 각 userIdx 값을 기반으로 GetUser 리스트 생성
+        List<GetUser> getUserList = new ArrayList<GetUser>();
+        String GetUserQuery = "select * from User where userIdx = ?";
+
+        for(int eachUserIdx : userIdxlist){
+            // DB 로 부터 User 를 얻어와서
+            GetUser eachUser = this.jdbcTemplate.queryForObject(GetUserQuery,
+                    (rs, rowNum) -> new GetUser(
+                            rs.getInt("userIdx"),
+                            rs.getTimestamp("createdAt"),
+                            rs.getString("email"),
+                            rs.getInt("is_connected"),
+                            rs.getString("nickname"),
+                            rs.getString("password"),
+                            rs.getString("status"),
+                            rs.getTimestamp("updatedAt"),
+                            rs.getString("userProfileImgUrl")),
+                    eachUserIdx);
+            // GetUser 리스트에 추가
+            getUserList.add(eachUser);
+        }
+
+        return getUserList;
     }
-     */
 }
 
 

--- a/src/main/java/maestrogroup/core/mapping/MappingDao.java
+++ b/src/main/java/maestrogroup/core/mapping/MappingDao.java
@@ -1,4 +1,58 @@
 package maestrogroup.core.mapping;
 
+import maestrogroup.core.mapping.model.Mapping;
+import maestrogroup.core.team.model.PostTeamReq;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+
+@Repository
 public class MappingDao {
+
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private void setDataSource(DataSource dataSource){
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    public void inviteUser(int teamIdx, int userIdx) {
+        String inviteUserQuery = "insert into Mapping (teamIdx, userIdx) VALUES (?, ?)";
+        Object[] inviteUserParams = new Object[]{teamIdx, userIdx};
+        this.jdbcTemplate.update(inviteUserQuery, inviteUserParams);
+    }
+
+    public void makeTeam(int userIdx, PostTeamReq postTeamReq){
+        String makeTeamQuery = "insert into Team (teamName, teamImgUrl) VALUES (?, ?)";
+        Object[] createTeamParams = new Object[]{postTeamReq.getTeamName(), postTeamReq.getTeamImgUrl()};
+        this.jdbcTemplate.update(makeTeamQuery, createTeamParams);
+
+        String makeMappingQuery = "insert into Mapping (teamIdx, userIdx) values (?, ?)";
+        String lastInsertTeamIdxQuery = "select last_insert_id()";      // teamIdx 값 추출
+        int teamIdx = this.jdbcTemplate.queryForObject(lastInsertTeamIdxQuery, int.class);
+
+        Object[] createMappingParams = new Object[]{teamIdx, userIdx};
+        this.jdbcTemplate.update(makeTeamQuery, createMappingParams); // Mapping 객체 생성
+    }
+    /*
+    public void createTeam(PostTeamReq postTeamReq) {
+        String createTeamQuery = "insert into Team (teamName, teamImgUrl) VALUES (?, ?)";
+        Object[] createUserParams = new Object[]{postTeamReq.getTeamName(), postTeamReq.getTeamImgUrl()};
+        this.jdbcTemplate.update(createTeamQuery, createUserParams);
+
+        String lastInsertTeamIdx = "select last_insert_id()";
+        String insertTeamQuery = "select * from Team where teamIdx = ?";
+    }
+     */
 }
+
+
+
+
+
+
+
+
+

--- a/src/main/java/maestrogroup/core/mapping/MappingProvider.java
+++ b/src/main/java/maestrogroup/core/mapping/MappingProvider.java
@@ -1,7 +1,23 @@
 package maestrogroup.core.mapping;
 
+import maestrogroup.core.mapping.model.Mapping;
+import maestrogroup.core.user.model.GetUser;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class MappingProvider {
+
+    @Autowired
+    private final MappingDao mappingDao;
+
+    public MappingProvider(MappingDao mappingDao){
+        this.mappingDao = mappingDao;
+    }
+
+    public List<GetUser> getTeamMembers(int teamIdx){
+        return mappingDao.getTeamMembers(teamIdx);
+    }
 }

--- a/src/main/java/maestrogroup/core/mapping/MappingProvider.java
+++ b/src/main/java/maestrogroup/core/mapping/MappingProvider.java
@@ -1,4 +1,7 @@
 package maestrogroup.core.mapping;
 
+import org.springframework.stereotype.Service;
+
+@Service
 public class MappingProvider {
 }

--- a/src/main/java/maestrogroup/core/mapping/MappingService.java
+++ b/src/main/java/maestrogroup/core/mapping/MappingService.java
@@ -1,10 +1,13 @@
 package maestrogroup.core.mapping;
 
 import maestrogroup.core.team.model.PostTeamReq;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class MappingService {
+
+    @Autowired
     private final MappingDao mappingDao;
 
     public MappingService(MappingDao mappingDao){

--- a/src/main/java/maestrogroup/core/mapping/MappingService.java
+++ b/src/main/java/maestrogroup/core/mapping/MappingService.java
@@ -1,4 +1,29 @@
 package maestrogroup.core.mapping;
 
+import maestrogroup.core.team.model.PostTeamReq;
+import org.springframework.stereotype.Service;
+
+@Service
 public class MappingService {
+    private final MappingDao mappingDao;
+
+    public MappingService(MappingDao mappingDao){
+        this.mappingDao = mappingDao;
+    }
+
+    public void makeTeam(int userIdx, PostTeamReq postTeamReq){
+        mappingDao.makeTeam(userIdx, postTeamReq);
+    }
+
+    public void inviteUser(int teamIdx, int userIdx){
+        mappingDao.inviteUser(teamIdx, userIdx);
+    }
 }
+
+
+
+
+
+
+
+

--- a/src/main/java/maestrogroup/core/mapping/model/GetUserIdx.java
+++ b/src/main/java/maestrogroup/core/mapping/model/GetUserIdx.java
@@ -1,0 +1,12 @@
+package maestrogroup.core.mapping.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetUserIdx {
+    int userIdx;
+}

--- a/src/main/java/maestrogroup/core/mapping/model/Mapping.java
+++ b/src/main/java/maestrogroup/core/mapping/model/Mapping.java
@@ -1,4 +1,15 @@
 package maestrogroup.core.mapping.model;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class Mapping {
+    int mappingIdx;
+    int important;
+    int teamIdx;
+    int userIdx;
 }

--- a/src/main/java/maestrogroup/core/team/model/PostTeamReq.java
+++ b/src/main/java/maestrogroup/core/team/model/PostTeamReq.java
@@ -1,8 +1,12 @@
 package maestrogroup.core.team.model;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class PostTeamReq {
     private String teamName;
     private String teamImgUrl;

--- a/src/main/java/maestrogroup/core/user/UserController.java
+++ b/src/main/java/maestrogroup/core/user/UserController.java
@@ -4,10 +4,7 @@ package maestrogroup.core.user;
 import maestrogroup.core.ExceptionHandler.BaseException;
 import maestrogroup.core.ExceptionHandler.BaseResponse;
 import maestrogroup.core.ExceptionHandler.BaseResponseStatus;
-import maestrogroup.core.user.model.GetUser;
-import maestrogroup.core.user.model.ModifyUserInfoReq;
-import maestrogroup.core.user.model.ModifyUserInfoRes;
-import maestrogroup.core.user.model.SignUpUserReq;
+import maestrogroup.core.user.model.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -41,6 +38,19 @@ public class UserController {
             return new BaseResponse(); // 생성자에 파라미터 값을 아무것도 부여하지 않으면 성공에 대한 BaseResponse 가 생성 및 호출됨
         } catch (BaseException exception) {  // userService.createUser() 를 호출했더니 도중에 예외가 발생한 경우에 대한 예외처리
             return new BaseResponse(exception.getStatus());
+        }
+    }
+
+    // 로그인
+    @ResponseBody
+    @PostMapping("/login")
+    public BaseResponse loginUser(@RequestBody LoginUserReq loginUserReq){
+        try {
+            userProvider.loginUser(loginUserReq);
+            //LoginUserRes loginUserRes = userProvider.loginUser(loginUserReq);
+            return new BaseResponse();
+        } catch(BaseException baseException){
+            return new BaseResponse(baseException.getStatus());
         }
     }
 

--- a/src/main/java/maestrogroup/core/user/UserDao.java
+++ b/src/main/java/maestrogroup/core/user/UserDao.java
@@ -1,8 +1,6 @@
 package maestrogroup.core.user;
 
-import maestrogroup.core.user.model.GetUser;
-import maestrogroup.core.user.model.ModifyUserInfoReq;
-import maestrogroup.core.user.model.SignUpUserReq;
+import maestrogroup.core.user.model.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -70,5 +68,19 @@ public class UserDao {
         String Email_Duplicate_Check_Query = "select exists(select email from User where email = ?)"; // 해당 email 값을 갖는 유저가 존재하는가?
         String checkEmailparams = email;
         return this.jdbcTemplate.queryForObject(Email_Duplicate_Check_Query, int.class, checkEmailparams); // 존재하면 1을, 존재하지 않으면 0을 리턴(int형 타입으로써 리턴)
+    }
+
+    public LoginUserSomeField getPwd(LoginUserReq loginUserReq){
+        String getPwdQuery = "select userIdx, password, email, nickname from User where email = ?";
+        String getPwdParams = loginUserReq.getEmail();
+        return this.jdbcTemplate.queryForObject(getPwdQuery,
+                (rs, rowNum) -> new LoginUserSomeField(
+                        rs.getInt("userIdx"),
+                        rs.getString("password"),
+                        rs.getString("email"),
+                        rs.getString("nickname")
+                ),
+                getPwdParams
+        );
     }
 }

--- a/src/main/java/maestrogroup/core/user/UserProvider.java
+++ b/src/main/java/maestrogroup/core/user/UserProvider.java
@@ -1,6 +1,12 @@
 package maestrogroup.core.user;
 
+import maestrogroup.core.ExceptionHandler.BaseException;
+import maestrogroup.core.ExceptionHandler.BaseResponse;
+import maestrogroup.core.ExceptionHandler.BaseResponseStatus;
 import maestrogroup.core.user.model.GetUser;
+import maestrogroup.core.user.model.LoginUserReq;
+import maestrogroup.core.user.model.LoginUserRes;
+import maestrogroup.core.user.model.LoginUserSomeField;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -19,5 +25,14 @@ public class UserProvider {
 
     public int Email_Duplicate_Check(String email){
         return userDao.Email_Duplicate_Check(email);
+    }
+
+    public void loginUser(LoginUserReq loginUserReq) throws BaseException {
+        try {
+            LoginUserSomeField loginUserSomeField = userDao.getPwd(loginUserReq);
+            String password;
+        } catch (Exception baseException){
+            throw new BaseException(BaseResponseStatus.LOGIN_FAILURE);
+        }
     }
 }

--- a/src/main/java/maestrogroup/core/user/model/LoginUserReq.java
+++ b/src/main/java/maestrogroup/core/user/model/LoginUserReq.java
@@ -1,6 +1,13 @@
 package maestrogroup.core.user.model;
 
-public class loginUserReq {
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginUserReq {
     private String email;
     private String password;
 }

--- a/src/main/java/maestrogroup/core/user/model/LoginUserRes.java
+++ b/src/main/java/maestrogroup/core/user/model/LoginUserRes.java
@@ -5,7 +5,7 @@ import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class loginUserRes {
+public class LoginUserRes {
     private int userIdx;
     private String email;
     private String nickname;

--- a/src/main/java/maestrogroup/core/user/model/LoginUserSomeField.java
+++ b/src/main/java/maestrogroup/core/user/model/LoginUserSomeField.java
@@ -1,0 +1,16 @@
+package maestrogroup.core.user.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+// userIdx, createdAt, email, is_connected, nickname, password, status, updatedAt, userProfileImgUrl
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginUserSomeField {
+    private int userIdx;
+    private String email;
+    private String nickname;
+    private String userPassword;
+}


### PR DESCRIPTION
다대다 관계(ManyToMany Relation) 을 위해 생성했던 Mapping 테이블에 대한 API 개발 브렌치입니다.

- makeTeam : Team 객체와 Mapping 객체를 생성

- inviteUser : 이전에 생성된 팀원 그룹에 특정 유저를 초대하기 : mapping 객체만 생성

-  deleteTeam : 해당 그룹을 특정 유저가 탈퇴할떄 Mapping 객체가 삭제되도록 구현 + 그리고 해당 그룹 팀의 총 인원수가 0명일떄, 그룹 객체(Team 객체)도 Mapping객체와 함께 삭제되도록 구현

- getTeamMembers : 특정 팀 그룹에 속하는 모든 팀멤버 출력 : ManyToMany

- getTeamList : 특정 유저가 속해있는 모든 팀 그룹 출력 : ManyToMany

=> 아직 deleteTeam 과 getTeamList 메소드에 대한 API 는 개발중에 있습니다. 초기 셋팅만 진행했으며, 개발이 되는대로 커밋 꾸준히 하고 PR 올리겠습니다!