### PR TITLE
fix: Mapping 모델 생성 관련 url 및 query 인자 수정

### DIFF
--- a/src/main/java/maestrogroup/core/mapping/MappingController.java
+++ b/src/main/java/maestrogroup/core/mapping/MappingController.java
@@ -39,7 +39,7 @@ public class MappingController {
 
     // team 객체와 mapping 객체를 생성
     @ResponseBody
-    @PostMapping("/makeTeam/{userIdx}")
+    @PostMapping("/makeTeam")
     public void makeTeam(@RequestBody PostTeamReq postTeamReq) throws BaseException {
         int userIdxByJwt = jwtService.getUserIdx();
         mappingService.makeTeam(userIdxByJwt, postTeamReq);

--- a/src/main/java/maestrogroup/core/mapping/MappingDao.java
+++ b/src/main/java/maestrogroup/core/mapping/MappingDao.java
@@ -43,7 +43,7 @@ public class MappingDao {
         int teamIdx = this.jdbcTemplate.queryForObject(lastInsertTeamIdxQuery, int.class);
 
         Object[] createMappingParams = new Object[]{teamIdx, userIdx};
-        this.jdbcTemplate.update(makeTeamQuery, createMappingParams); // Mapping 객체 생성
+        this.jdbcTemplate.update(makeMappingQuery, createMappingParams); // Mapping 객체 생성
     }
 
     // ManyToMany 다대다 관계 활용


### PR DESCRIPTION
## 변경 이유
- makeTeam 기능에서 userIdx는 jwtService.getUserIdx()를 통해 받으므로 필요가 없었습니다.
- this.jdbctemplate.update(~)을 통해 Mapping 모델이 생성되어야 하는데 Team 모델이 생성되었습니다.

## 변경 사항
- makeTeam 기능의 url에서 /{userIdx}를 삭제했습니다.
- Mapping 모델 생성 부분에서 makeTeamQuery 대신 makeMappingQuery로 수정했습니다.