### PR TITLE
feat: Music 모델 생성 기능 추가

### DIFF
--- a/src/main/java/maestrogroup/core/music/MusicController.java
+++ b/src/main/java/maestrogroup/core/music/MusicController.java
@@ -1,6 +1,7 @@
 package maestrogroup.core.music;
 
 import maestrogroup.core.music.model.Music;
+import maestrogroup.core.music.model.PostMusicReq;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,8 +24,14 @@ public class MusicController {
         this.musicService = musicService;
     }
 
-    @GetMapping("/{folderIdx}")
+    @GetMapping("getMusicList/{folderIdx}")
     public List<Music> GetAllMusic(@PathVariable("folderIdx") int folderIdx){
         return musicProvider.GetAllMusic(folderIdx);
+    }
+
+    @ResponseBody
+    @PostMapping("createMusic/{folderIdx}")
+    public void createMusic (@RequestBody PostMusicReq postMusicReq, @PathVariable int folderIdx) {
+        musicService.createMusic(postMusicReq, folderIdx);
     }
 }

--- a/src/main/java/maestrogroup/core/music/MusicDao.java
+++ b/src/main/java/maestrogroup/core/music/MusicDao.java
@@ -1,11 +1,13 @@
 package maestrogroup.core.music;
 
 import maestrogroup.core.music.model.Music;
+import maestrogroup.core.music.model.PostMusicReq;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
+import java.sql.Array;
 import java.util.List;
 
 @Repository
@@ -23,12 +25,17 @@ public class MusicDao {
         return this.jdbcTemplate.query(GetAllMusicQuery,
                 (rs, rowNum) -> new Music(
                  rs.getInt("musicIdx"),
-                 rs.getInt("BPM"),
+                 rs.getInt("bpm"),
                  rs.getInt("folderIdx"),
                  rs.getString("musicImgUrl"),
                         rs.getString("musicName"),
                         rs.getInt("circleNum"),
                         rs.getInt("totalNum")),
                 folderIdx);
+    }
+    public void createMusic(PostMusicReq postMusicReq, int folderIdx) {
+        String createMusicQuery = "insert into Music (musicName, bpm, circleNum, totalNum, musicImgUrl, folderIdx) VALUES (?, ?, ?, ?, ?, ?)";
+        Object[] createMusicParams = new Object[]{postMusicReq.getMusicName(), postMusicReq.getBpm(), postMusicReq.getCircleNum(), (double)60 / postMusicReq.getBpm() * postMusicReq.getCircleNum(), postMusicReq.getMusicImgUrl(), folderIdx};
+        this.jdbcTemplate.update(createMusicQuery, createMusicParams);
     }
 }

--- a/src/main/java/maestrogroup/core/music/MusicService.java
+++ b/src/main/java/maestrogroup/core/music/MusicService.java
@@ -1,7 +1,19 @@
 package maestrogroup.core.music;
 
+import maestrogroup.core.music.model.PostMusicReq;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class MusicService {
+    @Autowired
+    private final MusicDao musicDao;
+
+    public MusicService(MusicDao musicDao){
+        this.musicDao = musicDao;
+    }
+
+    public void createMusic(PostMusicReq postMusicReq, int folderIdx) {
+        musicDao.createMusic(postMusicReq, folderIdx);
+    }
 }

--- a/src/main/java/maestrogroup/core/music/model/PostMusicReq.java
+++ b/src/main/java/maestrogroup/core/music/model/PostMusicReq.java
@@ -7,14 +7,9 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class Music {
-    int musicIdx;
-    int bpm;
-    int folderIdx;
-    String musicImgUrl;
-    String musicName;
-    int circleNum;
-    int totalNum;
-
-
+public class PostMusicReq {
+    private String musicName;
+    private String musicImgUrl;
+    private int bpm;
+    private int circleNum;
 }


### PR DESCRIPTION
## 변경 이유
- Music 모델을 생성하는 기능이 필요했습니다.
- Request에서 key 값을 BPM으로 했을 때 처리가 되지 않았습니다.

## 변경 사항
Music모델 생성 관련
- Music 모델 생성 기능을 추가했습니다.
- MusicDao 내 createMusic의 createMusicParams의 4번째 인자값은 따로 계산하여 적용했습니다.
- totalNum은 메트로놈 애니메이션 작동 시, 각 동그라미가 반짝이는 주기를 말합니다.
- 이를 수치로 계산하면 60 / (bpm) * (애니메이션 내 동그라미 개수) 이므로 코드와 같이 계산하여 적용했습니다.

Bpm 관련
![스크린샷 2022-12-29 오전 4 03 18](https://user-images.githubusercontent.com/96401830/209865527-e612e436-f853-4601-a474-8dc37599cae5.png)
- 위와 같이 Request 내 key 값을 BPM으로 했을 때 처리가 되지 않았습니다.

![스크린샷 2022-12-29 오전 4 03 47](https://user-images.githubusercontent.com/96401830/209865577-5033f104-6615-4a3b-a6dc-1489cd0aeb26.png)
- 그러나, 이를 bpm으로 변경하여 적용하니 의도대로 작동하는 모습을 보였습니다.
- 사실 request 가 아닌 코드에서는 BPM을 bpm으로 변경하지 않아도 작동하는 데에는 차이가 없었지만, 혼돈을 방지하기 위해 모두 수정하였습니다.