### PR TITLE
feat: 애니메이션 동작에 필요한 특정 Music의 정보를 제공하는 기능 추가

### DIFF
--- a/src/main/java/maestrogroup/core/music/MusicController.java
+++ b/src/main/java/maestrogroup/core/music/MusicController.java
@@ -1,6 +1,7 @@
 package maestrogroup.core.music;
 
 import maestrogroup.core.music.model.Music;
+import maestrogroup.core.music.model.MusicInfoRes;
 import maestrogroup.core.music.model.PostMusicReq;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
@@ -33,5 +34,10 @@ public class MusicController {
     @PostMapping("createMusic/{folderIdx}")
     public void createMusic (@RequestBody PostMusicReq postMusicReq, @PathVariable int folderIdx) {
         musicService.createMusic(postMusicReq, folderIdx);
+    }
+
+    @GetMapping("getMusicInfo/{musicIdx}")
+    public List<MusicInfoRes> GetAllMusicInfo(@PathVariable("musicIdx") int musicIdx){
+        return musicProvider.GetMusicInfo(musicIdx);
     }
 }

--- a/src/main/java/maestrogroup/core/music/MusicDao.java
+++ b/src/main/java/maestrogroup/core/music/MusicDao.java
@@ -1,6 +1,7 @@
 package maestrogroup.core.music;
 
 import maestrogroup.core.music.model.Music;
+import maestrogroup.core.music.model.MusicInfoRes;
 import maestrogroup.core.music.model.PostMusicReq;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
 import java.sql.Array;
+import java.util.ArrayList;
 import java.util.List;
 
 @Repository
@@ -30,12 +32,38 @@ public class MusicDao {
                  rs.getString("musicImgUrl"),
                         rs.getString("musicName"),
                         rs.getInt("circleNum"),
-                        rs.getInt("totalNum")),
+                        rs.getDouble("totalNum")),
                 folderIdx);
     }
     public void createMusic(PostMusicReq postMusicReq, int folderIdx) {
         String createMusicQuery = "insert into Music (musicName, bpm, circleNum, totalNum, musicImgUrl, folderIdx) VALUES (?, ?, ?, ?, ?, ?)";
         Object[] createMusicParams = new Object[]{postMusicReq.getMusicName(), postMusicReq.getBpm(), postMusicReq.getCircleNum(), (double)60 / postMusicReq.getBpm() * postMusicReq.getCircleNum(), postMusicReq.getMusicImgUrl(), folderIdx};
         this.jdbcTemplate.update(createMusicQuery, createMusicParams);
+    }
+
+    public List<MusicInfoRes> GetMusicInfo(int musicIdx){
+        int bpm = this.jdbcTemplate.queryForObject("select bpm from Music where musicIdx = ?", int.class, musicIdx);
+        double waitTime = (double) 60 / bpm;
+        int circleNum = this.jdbcTemplate.queryForObject("select circleNum from Music where musicIdx = ?", int.class, musicIdx);
+
+        double num = 0;
+        List<Double> startTimes = new ArrayList<>();
+        for (int i = 0; i < circleNum; i++) {
+            startTimes.add(num);
+            num += waitTime;
+        }
+
+        String GetMusicInfoQuery = "select * from Music where musicIdx = ?";
+        return this.jdbcTemplate.query(GetMusicInfoQuery,
+                (rs, rowNum) -> new MusicInfoRes(
+                        rs.getInt("musicIdx"),
+                        rs.getInt("bpm"),
+                        rs.getInt("folderIdx"),
+                        rs.getString("musicImgUrl"),
+                        rs.getString("musicName"),
+                        rs.getInt("circleNum"),
+                        rs.getDouble("totalNum"),
+                        startTimes),
+                musicIdx);
     }
 }

--- a/src/main/java/maestrogroup/core/music/MusicProvider.java
+++ b/src/main/java/maestrogroup/core/music/MusicProvider.java
@@ -1,6 +1,7 @@
 package maestrogroup.core.music;
 
 import maestrogroup.core.music.model.Music;
+import maestrogroup.core.music.model.MusicInfoRes;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -18,5 +19,9 @@ public class MusicProvider {
 
     public List<Music> GetAllMusic(int folderIdx){
         return musicDao.GetAllMusic(folderIdx);
+    }
+
+    public List<MusicInfoRes> GetMusicInfo(int musicIdx){
+        return musicDao.GetMusicInfo(musicIdx);
     }
 }

--- a/src/main/java/maestrogroup/core/music/model/MusicInfoRes.java
+++ b/src/main/java/maestrogroup/core/music/model/MusicInfoRes.java
@@ -4,10 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.sql.Array;
+import java.util.List;
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class Music {
+public class MusicInfoRes {
     int musicIdx;
     int bpm;
     int folderIdx;
@@ -15,6 +18,5 @@ public class Music {
     String musicName;
     int circleNum;
     double totalNum;
-
-
+    List<Double> startTimes;
 }


### PR DESCRIPTION
FrontEnd 팀과 상의한 이후, 메트로놈 애니메이션을 구현하기 위해서 필요한 정보들을 전달받았고 이를 구현해야 했습니다.
![image](https://user-images.githubusercontent.com/96401830/209905946-75dd66d6-4678-459b-a9d0-56363742d64b.png)
메트로놈은 박자를 나타내는 역할을 해야 하므로, 위와 같이 동그라미가 각각 다르게 깜빡여야 합니다.
이때 추가된 정보인 startTimes 리스트에 포함된 정보들은 각 동그라미가 깜빡이기 전 기다리는 시간입니다.
각 동그라미마다 순차적으로 일정한 간격을 가지고 동작하기 시작해야 의도대로 작동하기 때문에 startTimes를 추가했습니다.

![image](https://user-images.githubusercontent.com/96401830/209906278-91610187-1ada-44ae-9597-14725049cf86.png)
위 사진이 이번 변경사항을 적용하여 특정 Music에 대한 정보를 받아낸 모습입니다.
- circleNum : 애니메이션에 필요한 동그라미 개수
- totalNum : 애니메이션 내에서 한 동그라미가 깜빡이는 시간 간격 (주기)
- startTimes : 애니메이션 내에서 각 동그라미가 깜빡이기 전, 기다려야 할 시간 (순차적으로 애니메이션을 시작할 수 있도록 제공하는 정보)

애니메이션 내 동그라미가 깜빡이는 주기를 나타내는 totalNum의 자료형이 잘못 나타나 있었습니다.
이에 따라 Model 내 totalNum을 double 형으로 수정하였습니다.

![image](https://user-images.githubusercontent.com/96401830/209906642-f0e02633-fbd9-4734-8d97-deeaeb4a7a26.png)
✔️ startTimes 리스트를 만드는 로직은 위와 같습니다. 우려되는 부분이나 고쳐야 할 부분이 있다면 말씀해주십시오.