### PR TITLE
Mapping 모델의 important 필드를 이용하는 기능 추가

### DIFF
--- a/src/main/java/maestrogroup/core/mapping/MappingController.java
+++ b/src/main/java/maestrogroup/core/mapping/MappingController.java
@@ -86,6 +86,12 @@ public class MappingController {
             return new BaseResponse(baseException.getStatus());
         }
     }
+
+    @PatchMapping("/changeImportanceOfTeam/{teamIdx}")
+    public void changeImportanceOfTeam(@PathVariable("teamIdx") int teamIdx) throws BaseException {
+        int userIdx = jwtService.getUserIdx();
+        mappingService.changeImportanceOfTeam(userIdx, teamIdx);
+    }
 }
 
 

--- a/src/main/java/maestrogroup/core/mapping/MappingController.java
+++ b/src/main/java/maestrogroup/core/mapping/MappingController.java
@@ -3,6 +3,7 @@ package maestrogroup.core.mapping;
 import maestrogroup.core.ExceptionHandler.BaseException;
 import maestrogroup.core.ExceptionHandler.BaseResponse;
 import maestrogroup.core.Security.JwtService;
+import maestrogroup.core.mapping.model.GetTeamAndImportantRes;
 import maestrogroup.core.team.model.GetTeamRes;
 import maestrogroup.core.team.model.PostTeamReq;
 import maestrogroup.core.user.model.GetUser;
@@ -91,6 +92,17 @@ public class MappingController {
     public void changeImportanceOfTeam(@PathVariable("teamIdx") int teamIdx) throws BaseException {
         int userIdx = jwtService.getUserIdx();
         mappingService.changeImportanceOfTeam(userIdx, teamIdx);
+    }
+
+    @GetMapping("/getTeamListAndImportant")
+    public BaseResponse<List<GetTeamAndImportantRes>> getTeamListAndImportant() throws BaseException {
+        try {
+            int userIdx = jwtService.getUserIdx();
+            List<GetTeamAndImportantRes> getTeamAndImportantResList = mappingProvider.getTeamAndImportant(userIdx);
+            return new BaseResponse<List<GetTeamAndImportantRes>>(getTeamAndImportantResList);
+        } catch (BaseException baseException) {
+            return new BaseResponse<>(baseException.getStatus());
+        }
     }
 }
 

--- a/src/main/java/maestrogroup/core/mapping/MappingDao.java
+++ b/src/main/java/maestrogroup/core/mapping/MappingDao.java
@@ -1,8 +1,10 @@
 package maestrogroup.core.mapping;
 
+import maestrogroup.core.mapping.model.GetTeamAndImportantRes;
 import maestrogroup.core.mapping.model.GetTeamIdx;
 import maestrogroup.core.mapping.model.GetUserIdx;
 import maestrogroup.core.mapping.model.Mapping;
+import maestrogroup.core.music.model.Music;
 import maestrogroup.core.team.model.GetTeamRes;
 import maestrogroup.core.team.model.PostTeamReq;
 import maestrogroup.core.user.model.GetUser;
@@ -140,6 +142,27 @@ public class MappingDao {
         String changeImportanceOfTeamQuery = "update Mapping set important = ? where teamIdx = ?";
         Object[] params = new Object[]{value, teamIdx};
         this.jdbcTemplate.update(changeImportanceOfTeamQuery, params);
+    }
+
+    public List<GetTeamAndImportantRes> getTeamAndImportant(int userIdx){
+        List<GetTeamAndImportantRes> result = new ArrayList<GetTeamAndImportantRes>();
+
+        List<Integer> teamIdxList = this.jdbcTemplate.queryForList("select teamIdx from Mapping where userIdx = ?", int.class, userIdx);
+        for (int teamIdx : teamIdxList) {
+
+            int important = this.jdbcTemplate.queryForObject("select important from Mapping where userIdx = ? AND teamIdx = ?", int.class, userIdx, teamIdx);
+
+            GetTeamAndImportantRes eachTeam = this.jdbcTemplate.queryForObject("select * from Team where teamIdx = ?",
+                    (rs, rowNum) -> new GetTeamAndImportantRes(
+                            rs.getInt("teamIdx"),
+                            rs.getString("teamName"),
+                            rs.getString("teamImgUrl"),
+                            rs.getInt("count"),
+                            important),
+                    teamIdx);
+            result.add(eachTeam);
+        }
+        return result;
     }
 }
 

--- a/src/main/java/maestrogroup/core/mapping/MappingDao.java
+++ b/src/main/java/maestrogroup/core/mapping/MappingDao.java
@@ -127,6 +127,20 @@ public class MappingDao {
         Object[] deleteTeamQueryParams = new Object[]{teamIdx, userIdx};
         this.jdbcTemplate.update(deleteTeamQuery, deleteTeamQueryParams);
     }
+
+    public void changeImportanceOfTeam(int userIdx, int teamIdx) {
+        int nowImportance = this.jdbcTemplate.queryForObject("select important from Mapping where userIdx = ? AND teamIdx = ?", int.class, userIdx, teamIdx);
+        int value = -1;
+        if (nowImportance == 1) {
+            value = 0;
+        }
+        if (nowImportance == 0) {
+            value = 1;
+        }
+        String changeImportanceOfTeamQuery = "update Mapping set important = ? where teamIdx = ?";
+        Object[] params = new Object[]{value, teamIdx};
+        this.jdbcTemplate.update(changeImportanceOfTeamQuery, params);
+    }
 }
 
 

--- a/src/main/java/maestrogroup/core/mapping/MappingProvider.java
+++ b/src/main/java/maestrogroup/core/mapping/MappingProvider.java
@@ -1,5 +1,6 @@
 package maestrogroup.core.mapping;
 
+import maestrogroup.core.mapping.model.GetTeamAndImportantRes;
 import maestrogroup.core.mapping.model.Mapping;
 import maestrogroup.core.team.model.GetTeamRes;
 import maestrogroup.core.user.model.GetUser;
@@ -24,5 +25,9 @@ public class MappingProvider {
 
     public List<GetTeamRes> getTeamList(int teamIdx){
         return mappingDao.getTeamList(teamIdx);
+    }
+
+    public List<GetTeamAndImportantRes> getTeamAndImportant(int userIdx) {
+        return mappingDao.getTeamAndImportant(userIdx);
     }
 }

--- a/src/main/java/maestrogroup/core/mapping/MappingService.java
+++ b/src/main/java/maestrogroup/core/mapping/MappingService.java
@@ -25,6 +25,10 @@ public class MappingService {
     public void deleteTeam(int teamIdx, int userIdx){
         mappingDao.deleteTeam(teamIdx, userIdx);
     }
+
+    public void changeImportanceOfTeam(int userIdx, int teamIdx) {
+        mappingDao.changeImportanceOfTeam(userIdx, teamIdx);
+    }
 }
 
 

--- a/src/main/java/maestrogroup/core/mapping/model/GetTeamAndImportantRes.java
+++ b/src/main/java/maestrogroup/core/mapping/model/GetTeamAndImportantRes.java
@@ -1,0 +1,16 @@
+package maestrogroup.core.mapping.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetTeamAndImportantRes {
+    private int teamIdx;
+    private String teamName;
+    private String teamImgUrl;
+    private int count;
+    private int important;
+}


### PR DESCRIPTION
## Important 수정 기능
- 유저 별로 팀의 중요도를 부여할 수 있는 기능을 추가했습니다.
<img width="260" alt="image" src="https://user-images.githubusercontent.com/96401830/209926172-ba4d352d-f0d1-4a9f-a244-b547528fd356.png">

- 위 사진에서 팀 옆에 별 표시 버튼을 누를 때 수행하는 기능입니다.
- 만약 기존의 important값이 0이라면 1로 변경하고, 0이었다면 1로 변경하도록 구현했습니다.

## 팀 목록에 important를 함께 띄워주는 기능
<img width="561" alt="스크린샷 2022-12-29 오후 5 32 39" src="https://user-images.githubusercontent.com/96401830/209926642-88403c1e-f2e8-4f58-9c9e-5c0729e8ae6e.png">

- 위와 같이 기존에 유저가 가입된 팀 목록을 띄워주는 url이 있었습니다.
- 그러나 해당 url은 팀의 중요도에 해당하는 important 값이 반영되지 않은 채 팀 목록을 띄워주었습니다.
<img width="533" alt="스크린샷 2022-12-29 오후 5 37 16" src="https://user-images.githubusercontent.com/96401830/209926660-b34777e1-9dd1-46df-8593-503403df53c0.png">

- 따라서 기존의 개발 의도대로, 중요한 팀을 먼저 띄울 수 있도록 important값을 추가해 띄워주는 기능을 추가했습니다.