### PR TITLE
User 관련 기능들 수정

### DIFF
--- a/src/main/java/maestrogroup/core/ExceptionHandler/BaseResponseStatus.java
+++ b/src/main/java/maestrogroup/core/ExceptionHandler/BaseResponseStatus.java
@@ -34,7 +34,10 @@ BaseResponseStatus {
     MODIFY_FIELD_NOT_FULL("아직 기입하지 않은 정보가 존재합니다!", HttpStatus.BAD_REQUEST),
     MODFIY_USER_FAILURE("프로틸을 수정하는데 실패했습니다.", HttpStatus.NOT_MODIFIED),
     PASSWORD_ENCRYPTION_FAILURE("비밀번호 암호화에 실패했습니다.", HttpStatus.NOT_ACCEPTABLE),
-    INVALID_TEAM_AUTH("팀장이 아니므로, 팀장 권한 부여가 불가능합니다.", HttpStatus.NOT_ACCEPTABLE);
+    INVALID_TEAM_AUTH("팀장이 아니므로, 팀장 권한 부여가 불가능합니다.", HttpStatus.NOT_ACCEPTABLE),
+
+    // 로그인 관련
+    INVALID_USER("존재하지 않는 회원입니다.", HttpStatus.BAD_REQUEST);
     private final HttpStatus httpStatus;
     private final String message;
 

--- a/src/main/java/maestrogroup/core/user/UserController.java
+++ b/src/main/java/maestrogroup/core/user/UserController.java
@@ -92,14 +92,16 @@ public class UserController {
         }
     }
 
-    //
-
-    // 계정 삭제 : status 필드값을 변경하자. DELETE 메소드 요청을 하지말고!!!
     @ResponseBody
-    @PatchMapping("/deleteUser/{userIdx}")
-    public void deleteUser(@PathVariable("userIdx") int userIdx){
-        Timestamp timestamp = new Timestamp(System.currentTimeMillis());
-        userService.deleteUser(userIdx, timestamp);
+    @DeleteMapping("/deleteUser")
+    public BaseResponse deleteUser() throws BaseException {
+        try {
+            int userIdx = jwtService.getUserIdx();
+            userService.deleteUser(userIdx);
+            return new BaseResponse();
+        } catch (BaseException baseException) {
+            return new BaseResponse(baseException.getStatus());
+        }
     }
 
     @ResponseBody

--- a/src/main/java/maestrogroup/core/user/UserController.java
+++ b/src/main/java/maestrogroup/core/user/UserController.java
@@ -105,8 +105,13 @@ public class UserController {
     }
 
     @ResponseBody
-    @GetMapping("/getUser/{userIdx}")
-    public GetUser getUser(@PathVariable("userIdx") int userIdx){
-        return userProvider.getUser(userIdx);
+    @GetMapping("/getUser")
+    public BaseResponse<GetUser> getUser(){
+        try {
+            int userIdx = jwtService.getUserIdx();
+            return new BaseResponse<GetUser>(userService.getUser(userIdx));
+        } catch (BaseException baseException) {
+            return new BaseResponse<>(baseException.getStatus());
+        }
     }
 }

--- a/src/main/java/maestrogroup/core/user/UserDao.java
+++ b/src/main/java/maestrogroup/core/user/UserDao.java
@@ -52,11 +52,9 @@ public class UserDao {
         this.jdbcTemplate.update(ModifyUserInfoQuery, ModifyUserInfoParams);
     }
 
-    public void deleteUser(int userIdx, Timestamp timestamp){
-        //System.out.println(simpleDateFormat.format(timestamp));
-        String deleteUserQuery = "update User set status = 'D', updatedAt = ? where userIdx = ?";
-        Object[] deleteUserQueryParams = new Object[]{timestamp, userIdx};
-        this.jdbcTemplate.update(deleteUserQuery, deleteUserQueryParams);
+    public void deleteUser(int userIdx){
+        String deleteUserQuery = "delete from User where userIdx = ?";
+        this.jdbcTemplate.update(deleteUserQuery, userIdx);
     }
 
     public GetUser getUser(int userIdx) {

--- a/src/main/java/maestrogroup/core/user/UserProvider.java
+++ b/src/main/java/maestrogroup/core/user/UserProvider.java
@@ -35,9 +35,15 @@ public class UserProvider {
 
     // 로그인 (password 검사)
     public LoginUserRes loginUser(LoginUserReq loginUserReq) throws BaseException {
-
-        // 회원가입시 저장한 회원 계정의 비밓번호와, 현재 로그인 창에서 입력된 비밀번호(loginUserSomeField가 동일한지 검증한다.
-        LoginUserSomeField loginUserSomeField = userDao.getSomeInfo_WhenLogin(loginUserReq); // 회원가입 때 입력받은 비밀번호를 DB에 그냥 저장한 것이 아니라 암호화해서
+        LoginUserSomeField loginUserSomeField = new LoginUserSomeField();
+        try {
+            // 회원가입시 저장한 회원 계정의 비밓번호와, 현재 로그인 창에서 입력된 비밀번호(loginUserSomeField가 동일한지 검증한다.
+            loginUserSomeField = userDao.getSomeInfo_WhenLogin(loginUserReq); // 회원가입 때 입력받은 비밀번호를 DB에 그냥 저장한 것이 아니라 암호화해서
+        } catch (Exception e) {
+            throw new BaseException(BaseResponseStatus.INVALID_USER);
+        }
+//        // 회원가입시 저장한 회원 계정의 비밓번호와, 현재 로그인 창에서 입력된 비밀번호(loginUserSomeField가 동일한지 검증한다.
+//        LoginUserSomeField loginUserSomeField = userDao.getSomeInfo_WhenLogin(loginUserReq); // 회원가입 때 입력받은 비밀번호를 DB에 그냥 저장한 것이 아니라 암호화해서
         String password;           // 저장했었는데, 아무튼 이 암호화된 비밀번호를 DB로부터 가져온다.
         try {
             // 복호화 : DB 에서 가져온 비밀번호를 암호화를 해제한다.(=> decrpyt 한다. 즉 인코딩(암호화)된 것을 다시 디코딩해준다.)

--- a/src/main/java/maestrogroup/core/user/UserService.java
+++ b/src/main/java/maestrogroup/core/user/UserService.java
@@ -118,8 +118,12 @@ public class UserService {
         }
     }
 
-    public void deleteUser(int userIdx, Timestamp timestamp){
-        userDao.deleteUser(userIdx, timestamp);
+    public void deleteUser(int userIdx) throws BaseException {
+        try {
+            userDao.deleteUser(userIdx);
+        } catch (Exception exception) {
+            throw new BaseException(BaseResponseStatus.SERVER_ERROR);
+        }
     }
 
     public GetUser getUser(int userIdx){

--- a/src/main/java/maestrogroup/core/user/UserService.java
+++ b/src/main/java/maestrogroup/core/user/UserService.java
@@ -1,6 +1,7 @@
 package maestrogroup.core.user;
 
 import maestrogroup.core.ExceptionHandler.BaseException;
+import maestrogroup.core.ExceptionHandler.BaseResponse;
 import maestrogroup.core.ExceptionHandler.BaseResponseStatus;
 import maestrogroup.core.ExceptionHandler.Validation.CheckValidForm;
 import maestrogroup.core.Security.AES128;
@@ -126,7 +127,11 @@ public class UserService {
         }
     }
 
-    public GetUser getUser(int userIdx){
-        return userDao.getUser(userIdx);
+    public GetUser getUser(int userIdx) throws BaseException {
+        try {
+            return userDao.getUser(userIdx);
+        } catch (Exception exception) {
+            throw new BaseException(BaseResponseStatus.SERVER_ERROR);
+        }
     }
 }


### PR DESCRIPTION
## 회원 탈퇴 기능
기존에는 탈퇴할 회원(User)에 대한 정보를 pathVariable로 받았습니다. 
그러나 회원 탈퇴는 주로 로그인을 한 상태로 이루어지기 때문에 
jwtservice.getUserIdx()를 통해 UserIdx를 얻도록 변경했습니다.

초기에는 회원 탈퇴 시, 계정 복구를 염두에 두어 탈퇴를 시도한 날짜를 기록한 후
기록된 날짜로부터 일정한 시간이 흐른 뒤 삭제되도록 구상하였습니다.
그러나 회의 끝에 즉시 삭제하는 방향으로 개발하기로 변경했기 때문에 이에 맞게 기능을 수정했습니다.

## 로그인 시, 가입되지 않은 회원일 경우에 대한 예외처리
로그인을 시도할 때, DB에 등록되지 않은 User 정보(email)를 입력받았을 때에 대한
예외처리를 추가했습니다. 
[src/main/java/maestrogroup/core/ExceptionHandler/BaseResponseStatus.java](https://github.com/likelion-maestro/Maestro-be/commit/87013fd9876a62e977aa6eac15c63c8655efc0e1#diff-0f915f497e1b0ea0e96abcc776f899240c34bdf2f3c3b28a71f77e81cb8fee85)
윗 부분을 수정했기 때문에 Merge 시 충돌을 주의해야 할 것 같습니다.

## 회원 정보 나타내는 기능 수정
기존에는 회원(User)에 대한 정보를 pathVariable로 받았습니다.
그러나 User 본인에 대한 정보는 주로 로그인 한 상태로 확인하기 때문에
jwtservice.getUserIdx()를 통해 UserIdx를 얻도록 변경했습니다.