### PR TITLE
Hotfix/logout authentication

### DIFF
--- a/src/main/java/maestrogroup/core/CorsConfiguration.java
+++ b/src/main/java/maestrogroup/core/CorsConfiguration.java
@@ -10,7 +10,7 @@ public class CorsConfiguration implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry){
         registry.addMapping("/**")  // 프로그램에서 제공하는 URL
-                .allowedOrigins("http://localhost:3000", "localhost:3000", "https://localhost:3000") // 클라이언트 주소. 어떤 출처들을 허용할 것인지
+                .allowedOrigins("http://localhost:3000", "localhost:3000", "https://localhost:3000", "https://maestrometronome.netlify.app/", "http://maestrometronome.netlify.app/") // 클라이언트 주소. 어떤 출처들을 허용할 것인지
                 .allowedHeaders("*") // 어떤 헤더들을 허용할 것인지
                 .allowedMethods("POST", "GET", "DELETE", "PATCH", "OPTIONS") // 어떤 메소드들을 허용할 것인지
                 .allowCredentials(true)  // Credentialed Request : 인증 관련 헤더를 포함할때 사용하는 요청 => true 로 설정해줘야 클라이언트 측에서 보낸것을 받을 수 있다.

--- a/src/main/java/maestrogroup/core/CorsConfiguration.java
+++ b/src/main/java/maestrogroup/core/CorsConfiguration.java
@@ -10,7 +10,7 @@ public class CorsConfiguration implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry){
         registry.addMapping("/**")  // 프로그램에서 제공하는 URL
-                .allowedOrigins("http://mastero:3000", "http://mastero.com:3000", "http://maestro.shop:3000", "http://www.maestro.com:3000") // 클라이언트 주소. 어떤 출처들을 허용할 것인지
+                .allowedOrigins("http://localhost:3000", "localhost:3000", "https://localhost:3000") // 클라이언트 주소. 어떤 출처들을 허용할 것인지
                 .allowedHeaders("*") // 어떤 헤더들을 허용할 것인지
                 .allowedMethods("POST", "GET", "DELETE", "PATCH", "OPTIONS") // 어떤 메소드들을 허용할 것인지
                 .allowCredentials(true)  // Credentialed Request : 인증 관련 헤더를 포함할때 사용하는 요청 => true 로 설정해줘야 클라이언트 측에서 보낸것을 받을 수 있다.

--- a/src/main/java/maestrogroup/core/Security/JwtController.java
+++ b/src/main/java/maestrogroup/core/Security/JwtController.java
@@ -23,9 +23,8 @@ public class JwtController {
     @ResponseBody
     @PostMapping("/getNewAccessToken")
     public BaseResponse<AccessToken> getNewAccessToken(){
-        String refreshToken = jwtService.getRefreshToken(); // HTTP Header를 통해 Access Token 과 Refresh Token 을 클라이언트로부터 전달받고
-        String originAccessToken = jwtService.getAccessToken();
-
+        // String refreshToken = jwtService.getRefreshToken(); // HTTP Header를 통해 Access Token 과 Refresh Token 을 클라이언트로부터 전달받고
+        // String originAccessToken = jwtService.getAccessToken();
         try{
             String newAccessToken = jwtService.ReCreateAccessToken();
             AccessToken returnAccessToken = new AccessToken(newAccessToken);

--- a/src/main/java/maestrogroup/core/Security/JwtRepository.java
+++ b/src/main/java/maestrogroup/core/Security/JwtRepository.java
@@ -37,6 +37,10 @@ public class JwtRepository {
                 dbRefreshToken);
     }
 
+    public void saveBlickList(String )
+
+
+
     public void changeNewRefreshToken(String updateRefreshToken, String originRefreshToken){
         String updateTokenQuery = "update RefreshToken set tokenContents = ? where tokenContents = ?";
         Object[] refreshTokenList = new Object[]{updateRefreshToken, originRefreshToken};

--- a/src/main/java/maestrogroup/core/Security/JwtRepository.java
+++ b/src/main/java/maestrogroup/core/Security/JwtRepository.java
@@ -37,9 +37,11 @@ public class JwtRepository {
                 dbRefreshToken);
     }
 
-    public void saveBlickList(String )
-
-
+    public void saveBlickList(int userIdx, String accessToken, int exp){
+        String saveTokenQuery = "insert into BlackList (userIdx, accessToken, expireDate) VALUES (?, ?, ?)";
+        Object[] saveTokenQueryParams = new Object[]{userIdx, accessToken, exp};
+        this.jdbcTemplate.update(saveTokenQuery, saveTokenQueryParams);
+    }
 
     public void changeNewRefreshToken(String updateRefreshToken, String originRefreshToken){
         String updateTokenQuery = "update RefreshToken set tokenContents = ? where tokenContents = ?";

--- a/src/main/java/maestrogroup/core/Security/JwtRepository.java
+++ b/src/main/java/maestrogroup/core/Security/JwtRepository.java
@@ -51,7 +51,7 @@ public class JwtRepository {
 
     public void modifyUserInfo(int userIdx, ModifyUserInfoReq modifyUserInfoReq){
         String ModifyUserInfoQuery = "update User set email = ?, nickname = ?, userProfileImgUrl = ?, password = ? where userIdx = ?";
-        Object[] ModifyUserInfoParams = new Object[]{modifyUserInfoReq.getEmail(), modifyUserInfoReq.getNickname(), modifyUserInfoReq.getUserProfileImgUrl(), modifyUserInfoReq.getPassword(), userIdx};
+        Object[] ModifyUserInfoParams = new Object[]{modifyUserInfoReq.getEmail(), modifyUserInfoReq.getNickname(), modifyUserInfoReq.getPassword(), userIdx};
         this.jdbcTemplate.update(ModifyUserInfoQuery, ModifyUserInfoParams);
     }
 

--- a/src/main/java/maestrogroup/core/Security/JwtService.java
+++ b/src/main/java/maestrogroup/core/Security/JwtService.java
@@ -175,7 +175,7 @@ public class JwtService {
     }
 
     public boolean checkAccessTokenExpired(String accessToken){
-
+        return true;
     }
 
     // 로그아웃 : 서버측에서 JWT 토큰값 자체를 변경하는 것은 불가능한 것으로 판단되어, DB에 존재하는
@@ -185,7 +185,7 @@ public class JwtService {
     public void makeExpireToken_WhenLogout() throws Exception{
         String refreshToken = getRefreshToken();
         String accessToken = getAccessToken();
-        String dbRefreshToken;
+        // String dbRefreshToken;
 
         Jws<Claims> claimsAccessToken;
         try {
@@ -196,42 +196,52 @@ public class JwtService {
             // accessToken 이 만료되지 않은 경우 아래의 구문들을 실행
             int userIdx = claimsAccessToken.getBody().get("userIdx", Integer.class);
             int exp = claimsAccessToken.getBody().get("exp", Integer.class);
+
             jwtRepository.saveBlickList(userIdx, accessToken, exp); // accessToken 에 대한 정보들을 블랙리스트에 저장
+            checkValidationOfRefreshToken(refreshToken);
+
         } catch(io.jsonwebtoken.ExpiredJwtException expiredJwtException){ // accessToken 이 만료된 경우 그냥 refreshToken에 대해 검증 및 만료시켜주면 된다.
-            // refresh token 유효성 검증1 : DB조회
-            try {
-                RefreshToken dbRefreshTokenObj = jwtRepository.getRefreshToken(refreshToken);
-                dbRefreshToken = dbRefreshTokenObj.getRefreshToken();
-            } catch(Exception ignored){  // DB에 RefreshToken 이 존재하지 않는경우
-                throw new BaseException(BaseResponseStatus.NOT_DB_CONNECTED_TOKEN);
-            }
+            checkValidationOfRefreshToken(refreshToken);
+        }
+    }
 
-            // DB에 RefreshToken이 존재하지 않거나(null), 전달받은 refeshToken 이 DB에 있는 refreshToken 과 일치하지 않는 경우
-            if(dbRefreshToken == null || !dbRefreshToken.equals(refreshToken)){
-                throw new BaseException(BaseResponseStatus.NOT_MATCHING_TOKEN);
-            }
+    public void checkValidationOfRefreshToken(String refreshToken) throws Exception{
+
+        String databassRefreshToken;
+
+        // refresh token 유효성 검증1 : DB조회
+        try {
+            RefreshToken dbRefreshTokenObj = jwtRepository.getRefreshToken(refreshToken);
+            databassRefreshToken = dbRefreshTokenObj.getRefreshToken();
+        } catch(Exception ignored){  // DB에 RefreshToken 이 존재하지 않는경우
+            throw new BaseException(BaseResponseStatus.NOT_DB_CONNECTED_TOKEN);
+        }
+
+        // DB에 RefreshToken이 존재하지 않거나(null), 전달받은 refeshToken 이 DB에 있는 refreshToken 과 일치하지 않는 경우
+        if(databassRefreshToken == null || !databassRefreshToken.equals(refreshToken)){
+            throw new BaseException(BaseResponseStatus.NOT_MATCHING_TOKEN);
+        }
 
 
-            Jws<Claims> claims;
-            try {
-                claims = Jwts.parserBuilder()
-                        .setSigningKey(Secret.REFRESH_TOKEN_SECRET_KEY)
-                        .build()
-                        .parseClaimsJws(refreshToken);
-            }  catch (io.jsonwebtoken.security.SignatureException signatureException){
-                throw new BaseException(BaseResponseStatus.INVALID_TOKEN);
-            }
-            catch (io.jsonwebtoken.ExpiredJwtException expiredJwtException) { // refresh token 이 만료된 경우
-                throw new BaseException(BaseResponseStatus.REFRESH_TOKEN_INVALID); // 새롭게 로그인읋 시도하라는 Response 를 보낸다.
-            } catch (Exception ignored) { // Refresh Token이 유효하지 않은 경우 (만료여부 외의 예외처리)
-                throw new BaseException(BaseResponseStatus.REFRESH_TOKEN_INVALID);
-            }
+        Jws<Claims> claims;
+        try {
+            claims = Jwts.parserBuilder()
+                    .setSigningKey(Secret.REFRESH_TOKEN_SECRET_KEY)
+                    .build()
+                    .parseClaimsJws(refreshToken);
+        }  catch (io.jsonwebtoken.security.SignatureException signatureException){
+            throw new BaseException(BaseResponseStatus.INVALID_TOKEN);
+        }
+        catch (io.jsonwebtoken.ExpiredJwtException expiredJwtException1) { // refresh token 이 만료된 경우
+            throw new BaseException(BaseResponseStatus.REFRESH_TOKEN_INVALID); // 새롭게 로그인읋 시도하라는 Response 를 보낸다.
+        } catch (Exception ignored) { // Refresh Token이 유효하지 않은 경우 (만료여부 외의 예외처리)
+            throw new BaseException(BaseResponseStatus.REFRESH_TOKEN_INVALID);
+        }
 
-            try {
-                jwtRepository.deleteRefreshToken(dbRefreshToken);
-            } catch(Exception exception){
-                throw new BaseException(BaseResponseStatus.LOGOUT_FAILED); // DB 에 있는 RefreshToken 삭제에 실패한 경우
-            }
+        try {
+            jwtRepository.deleteRefreshToken(databassRefreshToken);
+        } catch(Exception exception){
+            throw new BaseException(BaseResponseStatus.LOGOUT_FAILED); // DB 에 있는 RefreshToken 삭제에 실패한 경우
         }
     }
 }

--- a/src/main/java/maestrogroup/core/Security/JwtService.java
+++ b/src/main/java/maestrogroup/core/Security/JwtService.java
@@ -193,9 +193,10 @@ public class JwtService {
                     .setSigningKey(Secret.ACCESS_TOKEN_SECRET_KEY)
                     .build()
                     .parseClaimsJws(accessToken);
-
             // accessToken 이 만료되지 않은 경우 아래의 구문들을 실행
-            jwtRepository.saveBlickList();
+            int userIdx = claimsAccessToken.getBody().get("userIdx", Integer.class);
+            int exp = claimsAccessToken.getBody().get("exp", Integer.class);
+            jwtRepository.saveBlickList(userIdx, accessToken, exp); // accessToken 에 대한 정보들을 블랙리스트에 저장
         } catch(io.jsonwebtoken.ExpiredJwtException expiredJwtException){ // accessToken 이 만료된 경우 그냥 refreshToken에 대해 검증 및 만료시켜주면 된다.
             // refresh token 유효성 검증1 : DB조회
             try {

--- a/src/main/java/maestrogroup/core/Security/JwtService.java
+++ b/src/main/java/maestrogroup/core/Security/JwtService.java
@@ -193,10 +193,6 @@ public class JwtService {
             throw new BaseException(BaseResponseStatus.NOT_MATCHING_TOKEN);
         }
 
-        // DB에 RefreshToken이 존재하지 않거나(null), 전달받은 refeshToken 이 DB에 있는 refreshToken 과 일치하지 않는 경우
-        if(dbRefreshToken == null || !dbRefreshToken.equals(refreshToken)){
-            throw new BaseException(BaseResponseStatus.NOT_MATCHING_TOKEN);
-        }
 
         Jws<Claims> claims;
         try {

--- a/src/main/java/maestrogroup/core/Security/JwtService.java
+++ b/src/main/java/maestrogroup/core/Security/JwtService.java
@@ -178,6 +178,7 @@ public class JwtService {
     // RefreshToken 을 삭제시켜서 마치 로그아웃된 것으로 구현하기
     public void makeExpireToken_WhenLogout() throws Exception{
         String refreshToken = getRefreshToken();
+        String accessToken = getAccessToken();
         String dbRefreshToken;
 
         // refresh token 유효성 검증1 : DB조회

--- a/src/main/java/maestrogroup/core/mapping/MappingDao.java
+++ b/src/main/java/maestrogroup/core/mapping/MappingDao.java
@@ -72,14 +72,9 @@ public class MappingDao {
             GetUser eachUser = this.jdbcTemplate.queryForObject(GetUserQuery,
                     (rs, rowNum) -> new GetUser(
                             rs.getInt("userIdx"),
-                            rs.getTimestamp("createdAt"),
                             rs.getString("email"),
-                            rs.getInt("is_connected"),
                             rs.getString("nickname"),
-                            rs.getString("password"),
-                            rs.getString("status"),
-                            rs.getTimestamp("updatedAt"),
-                            rs.getString("userProfileImgUrl")),
+                            rs.getString("password")),
                     eachUserIdx);
             // GetUser 리스트에 추가
             getUserList.add(eachUser);

--- a/src/main/java/maestrogroup/core/user/UserController.java
+++ b/src/main/java/maestrogroup/core/user/UserController.java
@@ -84,7 +84,7 @@ public class UserController {
     public BaseResponse modifyUserInfo(@RequestBody ModifyUserInfoReq modifyUserInfoReq){
         try {
             int userIdxByJwt = jwtService.getUserIdx(); // 클라이언트로 부터 넘겨받은 JWT 토큰으로부터 userIdx 값 추출
-            //System.out.println("userIdxByJwt:" + userIdxByJwt);
+            System.out.println("userIdxByJwt:" + userIdxByJwt);
             userService.modifyUserInfo(userIdxByJwt, modifyUserInfoReq);
             return new BaseResponse();
         } catch(BaseException baseException){

--- a/src/main/java/maestrogroup/core/user/UserDao.java
+++ b/src/main/java/maestrogroup/core/user/UserDao.java
@@ -47,8 +47,8 @@ public class UserDao {
      */
 
     public void modifyUserInfo(int userIdx, ModifyUserInfoReq modifyUserInfoReq){
-        String ModifyUserInfoQuery = "update User set email = ?, nickname = ?, userProfileImgUrl = ?, password = ? where userIdx = ?";
-        Object[] ModifyUserInfoParams = new Object[]{modifyUserInfoReq.getEmail(), modifyUserInfoReq.getNickname(), modifyUserInfoReq.getUserProfileImgUrl(), modifyUserInfoReq.getPassword(), userIdx};
+        String ModifyUserInfoQuery = "update User set email = ?, nickname = ?, password = ? where userIdx = ?";
+        Object[] ModifyUserInfoParams = new Object[]{modifyUserInfoReq.getEmail(), modifyUserInfoReq.getNickname(), modifyUserInfoReq.getPassword(), userIdx};
         this.jdbcTemplate.update(ModifyUserInfoQuery, ModifyUserInfoParams);
     }
 
@@ -62,15 +62,9 @@ public class UserDao {
         return this.jdbcTemplate.queryForObject(GetUserQuery,
                 (rs, rowNum) -> new GetUser(
                         rs.getInt("userIdx"),
-                        rs.getTimestamp("createdAt"),
                         rs.getString("email"),
-                        rs.getInt("is_connected"),
                         rs.getString("nickname"),
-                        rs.getString("password"),
-                        rs.getString("status"),
-                        rs.getTimestamp("updatedAt"),
-                        rs.getString("userProfileImgU" +
-                                "rl")),
+                        rs.getString("password")),
                 userIdx);
     }
 

--- a/src/main/java/maestrogroup/core/user/UserProvider.java
+++ b/src/main/java/maestrogroup/core/user/UserProvider.java
@@ -73,6 +73,7 @@ public class UserProvider {
             jwtService.makeExpireToken_WhenLogout();
         }
         catch (Exception baseException){
+            System.out.println(baseException);
             throw new BaseException(BaseResponseStatus.ACCESS_TOKEN_EXPIRED);
         }
     }

--- a/src/main/java/maestrogroup/core/user/model/GetUser.java
+++ b/src/main/java/maestrogroup/core/user/model/GetUser.java
@@ -10,12 +10,7 @@ import java.sql.Timestamp;
 @AllArgsConstructor
 public class GetUser {
     private int userIdx;
-    private Timestamp createdAt;
     private String email;
-    private int is_connected;
     private String nickname;
     private String password;
-    private String status;
-    private Timestamp updatedAt;
-    private String userProfileImgUrl;
 }

--- a/src/main/java/maestrogroup/core/user/model/ModifyUserInfoReq.java
+++ b/src/main/java/maestrogroup/core/user/model/ModifyUserInfoReq.java
@@ -1,11 +1,14 @@
 package maestrogroup.core.user.model;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 // userIdx, createdAt, email, is_connected, nickname, password, status, updatedAt, userProfileImgUrl
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class ModifyUserInfoReq {
     private String email;
     private String nickname;
     private String password;
-    private String userProfileImgUrl;
 }

--- a/src/main/java/maestrogroup/core/user/model/SignUpUserReq.java
+++ b/src/main/java/maestrogroup/core/user/model/SignUpUserReq.java
@@ -16,6 +16,7 @@ public class SignUpUserReq {
     private String password;
     private String repass;
     private String nickname;
+    
 }
 // implementation 'org.springframework.boot:spring-boot-starter-validation' 로 의존성을 추가해야지 유효성 검사 관련 어노테이션 사용가능
 // https://victorydntmd.tistory.com/332


### PR DESCRIPTION
## 로그아웃 로직 리팩토링 및 버그수정

### 1. 로그아웃 로직

- 기존에 로그아웃 API 가 정말 미흡한 로직이 너무 많아, 우선 1차적으로 리팩토링을 진행했습니다.
- 기존의 로그아웃 요청시 무조건적으로 accessToke 이 만료되었다는 에러를 리턴하는 오류가 있었습니다. 이상함을 감지하고 버그 수정중이였습니다. ( 추후 검증 로직을 더 추가하고 다시 PR 올리겠습니다! )

accessToken 이 정상적으로 만료되고, 로그아웃이 정상적으로 수행되었다는 Response 를 확인할 수 있게되었습니다.

![image](https://user-images.githubusercontent.com/88240193/210044375-d34ca779-c0c9-4666-81df-f26b7ee4a3df.png)


### 2. 유저와 관련한 SQL 문 일부 수정 및  필드 수정
- 아까 말씀드린대로 RDS 에 필요없는 필드를 삭제시켰습니다.
-  삭제시켰더니, 기존에는 정상적으로 돌아가던 API들이 현재 없어진 필드들로 인해 오류가 발생하여 일부 SQL 문과 Request, Response를 수정했습니다.

### 3. 데이터베이스 블랙리스트(BlackList) 테이블 추가
- accessToken 이 만료되었는지 더 정확한 검증을 위해, 블랙리스트라는 테이블을 추가했습니다.
- 사실 좋은 방법은 아니라서, 추후 2차 배포때 NoSQL 을 사용하며 이 테이블을 삭제시키는 방향으로 구현  게획에 있습니다.
- 그리고 RDS 의 데이터베이스에서 블랙리스트 테이블의 모든 데이터를 30분에 한번씩 주기적으로 모두 삭제키셔주는 자동화 로직을 구현했습니다. 그 내용은 아래와 같습니다.

![image](https://user-images.githubusercontent.com/88240193/210044692-586efb31-f8e8-4d12-81db-81c0ea7cf2c7.png)

### 4. CORS 출처
- 프론트로부터 넘겨받은 배포 주소를 허용함으로써, 저희 API 및 리소스에 접근 가능하도록 설정해두었습니다.



