### PR TITLE
Hotfix/logout authentication : 로그아웃 구현 최종적으로 성공했습니다! (Redis 미사용)

### DIFF
--- a/src/main/java/maestrogroup/core/ExceptionHandler/BaseResponseStatus.java
+++ b/src/main/java/maestrogroup/core/ExceptionHandler/BaseResponseStatus.java
@@ -28,11 +28,13 @@ BaseResponseStatus {
     REFRESH_TOKEN_INVALID("유효하지 않은 Refresh Token 입니다.", HttpStatus.NOT_MODIFIED),
     REFRESH_TOKEN_EXPIRED("만료된 Refresh Token 입니다. 로그인을 새롭게 시도해주세요.", HttpStatus.NOT_ACCEPTABLE),
     ACCESS_TOKEN_EXPIRED(" 만료된 Access Token 입니다. 새로운 Access Token을 발급 받으세요. ", HttpStatus.NOT_ACCEPTABLE),
-    LOGOUT_FAILED("로그아웃에 실패했스니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    LOGOUT_FAILED("로그아웃에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+
+    BLACK_USER_EXIST("블랙리스트에 등록된 토큰입니다. 현재 유저는 로그아웃된 상태이므로, 다시 로그인을 시도해주세요.", HttpStatus.BAD_REQUEST),
 
     // 회원정보 수정 관련
     MODIFY_FIELD_NOT_FULL("아직 기입하지 않은 정보가 존재합니다!", HttpStatus.BAD_REQUEST),
-    MODFIY_USER_FAILURE("프로틸을 수정하는데 실패했습니다.", HttpStatus.NOT_MODIFIED),
+    MODFIY_USER_FAILURE("프로필을 수정하는데 실패했습니다.", HttpStatus.NOT_MODIFIED),
     PASSWORD_ENCRYPTION_FAILURE("비밀번호 암호화에 실패했습니다.", HttpStatus.NOT_ACCEPTABLE),
     INVALID_TEAM_AUTH("팀장이 아니므로, 팀장 권한 부여가 불가능합니다.", HttpStatus.NOT_ACCEPTABLE),
 

--- a/src/main/java/maestrogroup/core/Security/JwtRepository.java
+++ b/src/main/java/maestrogroup/core/Security/JwtRepository.java
@@ -1,6 +1,7 @@
 package maestrogroup.core.Security;
 
 
+import ch.qos.logback.core.encoder.EchoEncoder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import maestrogroup.core.ExceptionHandler.BaseException;
@@ -43,7 +44,6 @@ public class JwtRepository {
         String findBlackUserQuery = "select count(*) from BlackList where accessToken = ?";
         Object[] accessTokenQueryParams = new Object[]{accessTokenParam};
         Integer tokenCount = this.jdbcTemplate.queryForObject(findBlackUserQuery, accessTokenQueryParams, Integer.class);
-        System.out.println(tokenCount);
         return tokenCount;
     }
 
@@ -52,12 +52,10 @@ public class JwtRepository {
     // 단 특정 유저가 짧은 시간에 로그인을 여러번 시도해서 한 유저가 여러개의
     // 토큰을 지닐 수 있므므로 userIdx값이 아닌, 토큰값을 기준으로 판단하자.
     public void saveBlickList(int userIdx, String accessToken, int exp) throws BaseException {
-        try {
-            int tokenCount = checkDuplicateBlackAccessToken(accessToken);
-            if (tokenCount >= 2){
-                throw new BaseException(BaseResponseStatus.ACCESS_TOKEN_EXPIRED);
+        int tokenCount = checkDuplicateBlackAccessToken(accessToken);
+            if (tokenCount >= 2) {
+                throw new BaseException(BaseResponseStatus.BLACK_USER_EXIST);
             }
-        }
         String saveTokenQuery = "insert into BlackList (userIdx, accessToken, expireDate) VALUES (?, ?, ?)";
         Object[] saveTokenQueryParams = new Object[]{userIdx, accessToken, exp};
         this.jdbcTemplate.update(saveTokenQuery, saveTokenQueryParams);

--- a/src/main/java/maestrogroup/core/Security/JwtRepository.java
+++ b/src/main/java/maestrogroup/core/Security/JwtRepository.java
@@ -3,6 +3,8 @@ package maestrogroup.core.Security;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import maestrogroup.core.ExceptionHandler.BaseException;
+import maestrogroup.core.ExceptionHandler.BaseResponseStatus;
 import maestrogroup.core.Security.JWTtoken.RefreshToken;
 import maestrogroup.core.user.model.ModifyUserInfoReq;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,10 +51,13 @@ public class JwtRepository {
     // => 특정 토큰에 대한 블랙리스트 데이터는 유일성을 보장할 것, 즉 동일한 토큰을 또 보냈을 때 db에 저장되는 현상을 막자.
     // 단 특정 유저가 짧은 시간에 로그인을 여러번 시도해서 한 유저가 여러개의
     // 토큰을 지닐 수 있므므로 userIdx값이 아닌, 토큰값을 기준으로 판단하자.
-    public void saveBlickList(int userIdx, String accessToken, int exp){
-        int tokenCount = checkDuplicateBlackAccessToken(accessToken);
-        System.out.println(tokenCount);
-        System.out.println("===========================");
+    public void saveBlickList(int userIdx, String accessToken, int exp) throws BaseException {
+        try {
+            int tokenCount = checkDuplicateBlackAccessToken(accessToken);
+            if (tokenCount >= 2){
+                throw new BaseException(BaseResponseStatus.ACCESS_TOKEN_EXPIRED);
+            }
+        }
         String saveTokenQuery = "insert into BlackList (userIdx, accessToken, expireDate) VALUES (?, ?, ?)";
         Object[] saveTokenQueryParams = new Object[]{userIdx, accessToken, exp};
         this.jdbcTemplate.update(saveTokenQuery, saveTokenQueryParams);

--- a/src/main/java/maestrogroup/core/Security/JwtRepository.java
+++ b/src/main/java/maestrogroup/core/Security/JwtRepository.java
@@ -37,7 +37,22 @@ public class JwtRepository {
                 dbRefreshToken);
     }
 
+    public int checkDuplicateBlackAccessToken(String accessTokenParam){
+        String findBlackUserQuery = "select count(*) from BlackList where accessToken = ?";
+        Object[] accessTokenQueryParams = new Object[]{accessTokenParam};
+        Integer tokenCount = this.jdbcTemplate.queryForObject(findBlackUserQuery, accessTokenQueryParams, Integer.class);
+        System.out.println(tokenCount);
+        return tokenCount;
+    }
+
+    // 만료안된 accessToken을 계속 요청으로 보내서 블랙리스트 db에 과축적 되는 현상을 방지하기 위한 예외처리 요망
+    // => 특정 토큰에 대한 블랙리스트 데이터는 유일성을 보장할 것, 즉 동일한 토큰을 또 보냈을 때 db에 저장되는 현상을 막자.
+    // 단 특정 유저가 짧은 시간에 로그인을 여러번 시도해서 한 유저가 여러개의
+    // 토큰을 지닐 수 있므므로 userIdx값이 아닌, 토큰값을 기준으로 판단하자.
     public void saveBlickList(int userIdx, String accessToken, int exp){
+        int tokenCount = checkDuplicateBlackAccessToken(accessToken);
+        System.out.println(tokenCount);
+        System.out.println("===========================");
         String saveTokenQuery = "insert into BlackList (userIdx, accessToken, expireDate) VALUES (?, ?, ?)";
         Object[] saveTokenQueryParams = new Object[]{userIdx, accessToken, exp};
         this.jdbcTemplate.update(saveTokenQuery, saveTokenQueryParams);

--- a/src/main/java/maestrogroup/core/Security/JwtService.java
+++ b/src/main/java/maestrogroup/core/Security/JwtService.java
@@ -109,13 +109,6 @@ public class JwtService {
             throw new BaseException(BaseResponseStatus.ACCESS_TOKEN_EXPIRED);
         }
 
-        /*
-        // Access Token 유효성 검증2. accessToken의 만료 여부 검증
-        if (claims.getBody().getExpiration().before(new Date())) { // AccessToken 이 만료된 경우
-            throw new BaseException(BaseResponseStatus.ACCESS_TOKEN_EXPIRED);  // access token 이 만료되었다는 Response 를 보낸다.
-        }
-        */
-
         // userIdx 추출
         return claims.getBody().get("userIdx", Integer.class);  // jwt 에서 userIdx를 추출합니다.
     }
@@ -177,6 +170,8 @@ public class JwtService {
         String refreshToken = getRefreshToken();
         String accessToken = getAccessToken();
         // String dbRefreshToken;
+
+        // 만료안된걸 계속 보낼 수도 있지않나?
 
         Jws<Claims> claimsAccessToken;
         try {

--- a/src/main/java/maestrogroup/core/Security/JwtService.java
+++ b/src/main/java/maestrogroup/core/Security/JwtService.java
@@ -191,8 +191,7 @@ public class JwtService {
 
             jwtRepository.saveBlickList(userIdx, accessToken, exp); // accessToken 에 대한 정보들을 블랙리스트에 저장
             checkValidationOfRefreshToken(refreshToken);
-        }
-        catch(io.jsonwebtoken.ExpiredJwtException expiredJwtException){ // accessToken 이 만료된 경우 그냥 refreshToken에 대해 검증 및 만료시켜주면 된다.
+        } catch(io.jsonwebtoken.ExpiredJwtException expiredJwtException){ // accessToken 이 만료된 경우 그냥 refreshToken에 대해 검증 및 만료시켜주면 된다.
             checkValidationOfRefreshToken(refreshToken);
         }
     }
@@ -206,7 +205,6 @@ public class JwtService {
             RefreshToken dbRefreshTokenObj = jwtRepository.getRefreshToken(refreshToken);
             databassRefreshToken = dbRefreshTokenObj.getRefreshToken();
         } catch(Exception ignored){  // DB에 RefreshToken 이 존재하지 않는경우
-            System.out.println("=====");
             throw new BaseException(BaseResponseStatus.NOT_DB_CONNECTED_TOKEN);
         }
 
@@ -225,8 +223,8 @@ public class JwtService {
         }  catch (io.jsonwebtoken.security.SignatureException signatureException){
             throw new BaseException(BaseResponseStatus.INVALID_TOKEN);
         }
-        catch (io.jsonwebtoken.ExpiredJwtException expiredJwtException1) { // refresh token 이 만료된 경우
-            throw new BaseException(BaseResponseStatus.REFRESH_TOKEN_INVALID); // 새롭게 로그인읋 시도하라는 Response 를 보낸다.
+        catch (io.jsonwebtoken.ExpiredJwtException expiredJwtException) { // refresh token 이 만료된 경우
+            throw new BaseException(BaseResponseStatus.REFRESH_TOKEN_EXPIRED); // 새롭게 로그인읋 시도하라는 Response 를 보낸다.
         } catch (Exception ignored) { // Refresh Token이 유효하지 않은 경우 (만료여부 외의 예외처리)
             throw new BaseException(BaseResponseStatus.REFRESH_TOKEN_INVALID);
         }

--- a/src/main/java/maestrogroup/core/Security/JwtService.java
+++ b/src/main/java/maestrogroup/core/Security/JwtService.java
@@ -184,8 +184,13 @@ public class JwtService {
             int userIdx = claimsAccessToken.getBody().get("userIdx", Integer.class);
             int exp = claimsAccessToken.getBody().get("exp", Integer.class);
 
-            jwtRepository.saveBlickList(userIdx, accessToken, exp); // accessToken 에 대한 정보들을 블랙리스트에 저장
-            checkValidationOfRefreshToken(refreshToken);
+            try {
+                jwtRepository.saveBlickList(userIdx, accessToken, exp); // accessToken 에 대한 정보들을 블랙리스트에 저장
+                checkValidationOfRefreshToken(refreshToken);
+            } catch (BaseException baseException){
+                System.out.println(baseException);
+                throw baseException;
+            }
         } catch(io.jsonwebtoken.ExpiredJwtException expiredJwtException){ // accessToken 이 만료된 경우 그냥 refreshToken에 대해 검증 및 만료시켜주면 된다.
             checkValidationOfRefreshToken(refreshToken);
         }

--- a/src/main/java/maestrogroup/core/user/UserController.java
+++ b/src/main/java/maestrogroup/core/user/UserController.java
@@ -84,7 +84,6 @@ public class UserController {
     public BaseResponse modifyUserInfo(@RequestBody ModifyUserInfoReq modifyUserInfoReq){
         try {
             int userIdxByJwt = jwtService.getUserIdx(); // 클라이언트로 부터 넘겨받은 JWT 토큰으로부터 userIdx 값 추출
-            System.out.println("userIdxByJwt:" + userIdxByJwt);
             userService.modifyUserInfo(userIdxByJwt, modifyUserInfoReq);
             return new BaseResponse();
         } catch(BaseException baseException){

--- a/src/main/java/maestrogroup/core/user/UserProvider.java
+++ b/src/main/java/maestrogroup/core/user/UserProvider.java
@@ -1,5 +1,6 @@
 package maestrogroup.core.user;
 
+import com.fasterxml.jackson.databind.ser.Serializers;
 import maestrogroup.core.ExceptionHandler.BaseException;
 import maestrogroup.core.ExceptionHandler.BaseResponse;
 import maestrogroup.core.ExceptionHandler.BaseResponseStatus;
@@ -72,9 +73,8 @@ public class UserProvider {
         try {
             jwtService.makeExpireToken_WhenLogout();
         }
-        catch (Exception baseException){
-            System.out.println(baseException);
-            throw new BaseException(BaseResponseStatus.ACCESS_TOKEN_EXPIRED);
+        catch (BaseException baseException){
+            throw baseException;
         }
     }
 }

--- a/src/main/java/maestrogroup/core/user/UserService.java
+++ b/src/main/java/maestrogroup/core/user/UserService.java
@@ -111,7 +111,6 @@ public class UserService {
             throw new BaseException(BaseResponseStatus.INVALID_PASSWORD_FORM);
         }
 
-
         try {
             userDao.modifyUserInfo(userIdx, modifyUserInfoReq);
         } catch(Exception exception) { // 서버 및 DB 에 연동해서 데이터를 Dao에서 데이터를 처리할 떄 문제가 발생한 경우


### PR DESCRIPTION
## Redis 를 사용하지 않고 RDBMS 만으로 로그아웃에 대한 최종 기능을 구현했습니다.

- 기존 로그아웃 API 호출시 문제점은, ExipreDate 가 지나지 않은 (만료되지 않은) accessToken 을 계속 요청을 보낼시 블랙리스트 DB에 과축적되는 현상이 있었습니다.

- 이 문제점을 해결하기 위한 예외처리를 구현했습니다. 특정 토큰에 대한 블랙리스트이 데이터를 유일성이 보장되어야합니다. 즉, 동일한 토큰을 또 전송받았을 떄 DB에 저장되는 현상을 방지했습니다.

- 단, 특정 유저가 짧은 시간내에 만료되지 않은 AccessToken 으로 로그인을 여러번 시도해서 한 유저가 여러개의 토큰을 지닐 수 있습니다.

-  이를 위해 userIdx 값이 아닌, 토큰값을 기준으로 판단하는 로직을 구현했습니다.

- 또한 아까 말씀드렸듯이, SQL Event 를 통해 30분에 한번씩 블랙리스트 테이블의 모든 accessToken 값이  자동 삭제되도록 구현했습니다.

## 로직 구현 내용

예를들어 아래와 같이 로그인 API를 호출해서 AccessToken 과 RefreshToken 을 발급받고, 클라이언트의 local Storage에 저장했다고 가정해봅시다.

![image](https://user-images.githubusercontent.com/88240193/210083462-4a8a822e-0863-41fe-a15c-337e474f602e.png)

만일 이 상황에서 로그아웃 API 를 호출하면, AccessToken 과 RefreshToken 은 더이상 사용할 수 없어야합니다 
그러나 문제점은 아직 accessToken 이 만료되지 않을 수 있다는 점입니다.

![image](https://user-images.githubusercontent.com/88240193/210083758-126aca7f-5924-488e-b839-13c55b8454eb.png)

이때 만료되지 않은 것은 블랙리스트로 관리할텐데, 중복되서 저장될 수 있습니다. 이를 방지하기 위한 로직을 처리한 내용입니다.

![image](https://user-images.githubusercontent.com/88240193/210083911-75fd02a9-be92-4288-b87f-7084b18b7708.png)











