### PR TITLE
팀원 수 나타내는 count 값 계산하는 기능 추가

### DIFF
--- a/src/main/java/maestrogroup/core/mapping/MappingController.java
+++ b/src/main/java/maestrogroup/core/mapping/MappingController.java
@@ -57,7 +57,8 @@ public class MappingController {
 
     // 이전에 생성된 팀원 그룹에 특정 유저를 초대하기 : mapping 객체만 생성함
     @PostMapping("/inviteUser/{teamIdx}/{userIdx}")
-    public void inviteUser(@PathVariable("teamIdx") int teamIdx, @PathVariable("userIdx") int userIdx) {
+    public void inviteUser(@PathVariable("teamIdx") int teamIdx) throws BaseException {
+        int userIdx = jwtService.getUserIdx();
         mappingService.inviteUser(teamIdx, userIdx);
     }
 

--- a/src/main/java/maestrogroup/core/mapping/MappingDao.java
+++ b/src/main/java/maestrogroup/core/mapping/MappingDao.java
@@ -129,6 +129,15 @@ public class MappingDao {
         String deleteTeamQuery = "delete from Mapping where teamIdx = ? AND userIdx = ?";
         Object[] deleteTeamQueryParams = new Object[]{teamIdx, userIdx};
         this.jdbcTemplate.update(deleteTeamQuery, deleteTeamQueryParams);
+
+        //해당 팀의 count를 감소시키는 부분
+        int nowCount = this.jdbcTemplate.queryForObject("select count from Team where teamIdx = ?", int.class, teamIdx);
+        nowCount -= 1;
+
+        Object[] updateCountParams = new Object[]{nowCount, teamIdx};
+        this.jdbcTemplate.update("update Team set count = ? where teamIdx = ?", updateCountParams);
+
+        //if nowCount <= 0: 팀 삭제 기능 추후에 추가!
     }
 
     public void changeImportanceOfTeam(int userIdx, int teamIdx) {

--- a/src/main/java/maestrogroup/core/mapping/MappingDao.java
+++ b/src/main/java/maestrogroup/core/mapping/MappingDao.java
@@ -30,9 +30,17 @@ public class MappingDao {
     }
 
     public void inviteUser(int teamIdx, int userIdx) {
+        //초대하는 부분
         String inviteUserQuery = "insert into Mapping (teamIdx, userIdx) VALUES (?, ?)";
         Object[] inviteUserParams = new Object[]{teamIdx, userIdx};
         this.jdbcTemplate.update(inviteUserQuery, inviteUserParams);
+
+        //해당 팀의 count를 증가시키는 부분
+        int nowCount = this.jdbcTemplate.queryForObject("select count from Team where teamIdx = ?", int.class, teamIdx);
+        nowCount += 1;
+
+        Object[] updateCountParams = new Object[]{nowCount, teamIdx};
+        this.jdbcTemplate.update("update Team set count = ? where teamIdx = ?", updateCountParams);
     }
 
     public void makeTeam(int userIdx, PostTeamReq postTeamReq){

--- a/src/main/java/maestrogroup/core/mapping/MappingDao.java
+++ b/src/main/java/maestrogroup/core/mapping/MappingDao.java
@@ -36,7 +36,7 @@ public class MappingDao {
     }
 
     public void makeTeam(int userIdx, PostTeamReq postTeamReq){
-        String makeTeamQuery = "insert into Team teamName VALUES ?";
+        String makeTeamQuery = "insert into Team (teamName, count) VALUES (?, 1)";
         this.jdbcTemplate.update(makeTeamQuery, postTeamReq.getTeamName());
 
         String makeMappingQuery = "insert into Mapping (teamIdx, userIdx) values (?, ?)";

--- a/src/main/java/maestrogroup/core/user/UserDao.java
+++ b/src/main/java/maestrogroup/core/user/UserDao.java
@@ -9,6 +9,7 @@ import javax.sql.DataSource;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
+import java.util.List;
 import java.util.TimeZone;
 
 @Repository
@@ -53,6 +54,19 @@ public class UserDao {
     }
 
     public void deleteUser(int userIdx){
+        //삭제할 User가 가입되어 있는 Team의 teamIdx를 불러옴
+        List<Integer> teamIdxList = this.jdbcTemplate.queryForList("select teamIdx from Mapping where userIdx = ?", int.class, userIdx);
+
+        for (int teamIdx : teamIdxList) {
+            //해당 팀의 count를 감소시키는 부분
+            int nowCount = this.jdbcTemplate.queryForObject("select count from Team where teamIdx = ?", int.class, teamIdx);
+            nowCount -= 1;
+
+            Object[] updateCountParams = new Object[]{nowCount, teamIdx};
+            this.jdbcTemplate.update("update Team set count = ? where teamIdx = ?", updateCountParams);
+        }
+
+        //User 삭제
         String deleteUserQuery = "delete from User where userIdx = ?";
         this.jdbcTemplate.update(deleteUserQuery, userIdx);
     }


### PR DESCRIPTION
## 변경 이유
Team 테이블 내 count 필드를 만들어놓았지만 사용하지 않고 있었습니다. 
따라서 해당 필드를 계산하는 기능을 추가했습니다.

특정 User를 초대하는 기능이 구상한 방식과 다르게 개발되어 있었습니다.

## 변경 사항
Team에 가입하고 있는 User의 수를 나타내는 count 값에 영향을 주는 
Team 생성, 가입, 탈퇴, 그리고 User 탈퇴 기능에 count 값을 계산하는 과정을 추가했습니다.

![image](https://user-images.githubusercontent.com/96401830/210090001-96b3efff-b9ce-4d8b-8c1f-632e1f1dfbe8.png)
Team 생성 시에 count를 1로 설정하도록 했습니다.
서비스 흐름 상 팀을 생성함과 동시에 팀을 생성한 유저가 가입처리 되기 때문입니다.

<img width="266" alt="스크린샷 2022-12-30 오후 5 22 26" src="https://user-images.githubusercontent.com/96401830/210090072-db3a562a-abda-46af-b2c9-7bec3b201c28.png">
특정 User가 Team에 가입할 때 Team의 기존 count값에서 1씩 증가하도록 했습니다.

위와 동일한 방식으로 특정 User가 Team을 탈퇴할 때 Team의 기존 count 값에서 1씩 감소하도록 했습니다.

특정 User가 서비스 내에서 탈퇴를 할 때, 
해당 User가 가입했던 Team들의 count를 1씩 감소하도록 처리했습니다.

특정 User를 Team에 초대할 때, user의 대한 정보를 jwt를 통해 불러오도록 변경했습니다.
팀에 초대하는 기능은 해당 링크(url)을 상대방에게 기타 메신저를 통해 직접 전달하고
상대방이 해당 링크를 클릭했을 때 초대가 이루어지는 방식을 구상했기 때문에
상대방 User에 대한 정보를 jwt를 통해 불러오는 방식으로 수정했습니다.