### PR TITLE
Swagger 설명, Request, Response 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 
 	//Swagger
 	implementation 'io.springfox:springfox-boot-starter:3.0.0'
+	implementation 'io.springfox:springfox-swagger-ui:3.0.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/maestrogroup/core/Security/JWTtoken/AccessToken.java
+++ b/src/main/java/maestrogroup/core/Security/JWTtoken/AccessToken.java
@@ -1,5 +1,6 @@
 package maestrogroup.core.Security.JWTtoken;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,5 +9,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class AccessToken {
+    @ApiModelProperty(example = "eyJ0eXBlIjoiand0IiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VySWR4IjoxMSwiaWF0IjoxNjcyNTg3MjgxLCJleHAiOjE2NzI1ODkwODF9.0zPVjNqR3B9vlCvYM6h3fdMduJoh6gak5mowOv84-KU")
     String accessToken;
 }

--- a/src/main/java/maestrogroup/core/Security/JWTtoken/RefreshToken.java
+++ b/src/main/java/maestrogroup/core/Security/JWTtoken/RefreshToken.java
@@ -1,5 +1,6 @@
 package maestrogroup.core.Security.JWTtoken;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,5 +9,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RefreshToken{
+    @ApiModelProperty(example = "eyJ0eXBlIjoiand0IiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VySWR4IjoxMSwiaWF0IjoxNjcyNTg3MjgxLCJleHAiOjE2NzMxOTIwODF9.oCGljA9e36qJoDS9jsfO3nLijNYoxvHM3ib01UF8-68")
     String refreshToken;
 }

--- a/src/main/java/maestrogroup/core/Security/JWTtoken/Token.java
+++ b/src/main/java/maestrogroup/core/Security/JWTtoken/Token.java
@@ -1,5 +1,6 @@
 package maestrogroup.core.Security.JWTtoken;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,6 +9,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class Token {
+    @ApiModelProperty(example = "eyJ0eXBlIjoiand0IiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VySWR4IjoxMSwiaWF0IjoxNjcyNTg3MjgxLCJleHAiOjE2NzMxOTIwODF9.oCGljA9e36qJoDS9jsfO3nLijNYoxvHM3ib01UF8-68")
     private String refreshToken;
+
+    @ApiModelProperty(example = "eyJ0eXBlIjoiand0IiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VySWR4IjoxMSwiaWF0IjoxNjcyNTg3MjgxLCJleHAiOjE2NzI1ODkwODF9.0zPVjNqR3B9vlCvYM6h3fdMduJoh6gak5mowOv84-KU")
     private String accessToken;
 }

--- a/src/main/java/maestrogroup/core/config/SwaggerConfig.java
+++ b/src/main/java/maestrogroup/core/config/SwaggerConfig.java
@@ -6,9 +6,15 @@ import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.ApiKey;
+import springfox.documentation.service.AuthorizationScope;
+import springfox.documentation.service.SecurityReference;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.List;
 
 // config/SwaggerConfig.java
 @Configuration
@@ -18,6 +24,8 @@ public class SwaggerConfig {  // Swagger
     private static final String API_NAME = "Maestro API";
     private static final String API_VERSION = "0.0.1";
     private static final String API_DESCRIPTION = "Maestro API 명세서";
+    private static final String REFERENCE = "Authorization 헤더 값";
+
 
     @Bean
     public Docket api() {
@@ -25,9 +33,31 @@ public class SwaggerConfig {  // Swagger
                 .select()
                 .apis(RequestHandlerSelectors.basePackage("maestrogroup.core"))  // Swagger를 적용할 클래스의 package명
                 .paths(PathSelectors.any())  // 해당 package 하위에 있는 모든 url에 적용
+                .build()
+                .securityContexts(List.of(securityContext()))
+                .securitySchemes(List.of(securityScheme()));
+    }
+
+    private SecurityContext securityContext() {
+        return springfox.documentation
+                .spi.service.contexts
+                .SecurityContext
+                .builder()
+                .securityReferences(defaultAuth())
+                .operationSelector(operationContext -> true)
                 .build();
     }
 
+    private List<SecurityReference> defaultAuth() {
+        AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+        authorizationScopes[0] = new AuthorizationScope("global", "accessEverything");
+        return List.of(new SecurityReference(REFERENCE, authorizationScopes));
+    }
+
+    private ApiKey securityScheme() {
+        String targetHeader = "Authorization";
+        return new ApiKey(REFERENCE, targetHeader, "header");
+    }
 
     public ApiInfo apiInfo() {  // API의 이름, 현재 버전, API에 대한 정보
         return new ApiInfoBuilder()

--- a/src/main/java/maestrogroup/core/folder/FolderController.java
+++ b/src/main/java/maestrogroup/core/folder/FolderController.java
@@ -1,5 +1,6 @@
 package maestrogroup.core.folder;
 
+import io.swagger.v3.oas.annotations.Operation;
 import maestrogroup.core.ExceptionHandler.BaseException;
 import maestrogroup.core.ExceptionHandler.BaseResponse;
 import maestrogroup.core.ExceptionHandler.BaseResponseStatus;
@@ -40,6 +41,7 @@ public class FolderController {
     // folderIdx, folderImgUrl, folderName, teamIdx
     @ResponseBody
     @PostMapping("/create_folder/{teamIdx}")
+    @Operation(summary = "폴더 생성", description = "특정 팀의 폴더를 생성합니다.")
     public BaseResponse createFolder(@PathVariable("teamIdx") int teamIdx, @RequestBody PostFolderReq postFolderReq) {
         try {
             folderService.createFolder(postFolderReq, teamIdx);
@@ -52,6 +54,7 @@ public class FolderController {
     // 특정 팀에 대한 폴더 리스트 조회
     @ResponseBody
     @GetMapping("/get_all_folder/{teamIdx}")
+    @Operation(summary = "특정 팀의 폴더 목록 조회")
     public BaseResponse<List<Folder>> GetAllFolder(@PathVariable("teamIdx") int teamIdx) throws BaseException{
         try {
             List<Folder> folderList = folderProvider.GetAllFolder(teamIdx);
@@ -68,6 +71,7 @@ public class FolderController {
     // 해당 폴더에 저장되어있던 값들을 수정란에 띄어주는 것으로 가정
     @ResponseBody
     @PatchMapping("/patchFolder/{folderIdx}/{teamIdx}")
+    @Operation(summary = "폴더 정보 수정", description = "폴더 이름을 수정합니다.")
     public BaseResponse modifyFolder(@PathVariable("folderIdx") int folderIdx, @PathVariable("teamIdx") int teamIdx, @RequestBody ModifyFolderReq modifyFolderReq) {
         try {
             folderService.modifyFolder(folderIdx, teamIdx, modifyFolderReq);
@@ -80,6 +84,7 @@ public class FolderController {
     // 폴더를 삭제할떄 폴더안에 담겨있는 음악 객체들도 모두 삭제되도록 API 추가 개발 처리요망
     @ResponseBody
     @DeleteMapping("/deleteFolder/{folderIdx}")
+    @Operation(summary = "폴더 삭제")
     public BaseResponse deleteFolder(@PathVariable("folderIdx") int folderIdx) {
         try {
             folderService.deleteFolder(folderIdx);
@@ -91,6 +96,7 @@ public class FolderController {
 
     @ResponseBody
     @PatchMapping("changeImportantOfFolder/{folderIdx}")
+    @Operation(summary = "폴더 별 표시 기능", description = "폴더의 중요도를 나타내는 별 표시 기능입니다. important가 0이라면 1이 되고, 1이라면 0이 되도록 구현했습니다.")
     public BaseResponse changeImportantOfFolder(@PathVariable("folderIdx") int folderIdx) {
         try {
             folderService.changeImportantOfFolder(folderIdx);

--- a/src/main/java/maestrogroup/core/folder/FolderController.java
+++ b/src/main/java/maestrogroup/core/folder/FolderController.java
@@ -1,5 +1,6 @@
 package maestrogroup.core.folder;
 
+import io.swagger.annotations.Api;
 import io.swagger.v3.oas.annotations.Operation;
 import maestrogroup.core.ExceptionHandler.BaseException;
 import maestrogroup.core.ExceptionHandler.BaseResponse;
@@ -13,7 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-
+@Api(value = "Folder", tags = "Folder 관련 API")
 @RestController
 public class FolderController {
 

--- a/src/main/java/maestrogroup/core/folder/model/Folder.java
+++ b/src/main/java/maestrogroup/core/folder/model/Folder.java
@@ -1,5 +1,6 @@
 package maestrogroup.core.folder.model;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -7,9 +8,16 @@ import lombok.Data;
 
 @Data
 public class Folder {
+    @ApiModelProperty(example = "3")
     private int folderIdx;
+
+    @ApiModelProperty(example = "크리스마스 기념 공연 곡 모음")
     private String folderName;
+
+    @ApiModelProperty(example = "4")
     private int teamIdx;
+
+    @ApiModelProperty(example = "1")
     private int important;
 
     public Folder(int folderIdx, String folderName, int teamIdx, int important) {

--- a/src/main/java/maestrogroup/core/folder/model/PostFolderReq.java
+++ b/src/main/java/maestrogroup/core/folder/model/PostFolderReq.java
@@ -1,5 +1,6 @@
 package maestrogroup.core.folder.model;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class PostFolderReq {
+    @ApiModelProperty(example = "크리스마스 기념 공연 곡 모음")
     private String folderName;
     //private int teamIdx;
 }

--- a/src/main/java/maestrogroup/core/folder/model/patchFolderReq.java
+++ b/src/main/java/maestrogroup/core/folder/model/patchFolderReq.java
@@ -1,5 +1,6 @@
 package maestrogroup.core.folder.model;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class patchFolderReq {
+    @ApiModelProperty(example = "크리스마스 기념 곡 모음집")
     private String folderName;
 
 }

--- a/src/main/java/maestrogroup/core/mapping/MappingController.java
+++ b/src/main/java/maestrogroup/core/mapping/MappingController.java
@@ -1,5 +1,7 @@
 package maestrogroup.core.mapping;
 
+import io.swagger.annotations.Api;
+import io.swagger.v3.oas.annotations.Operation;
 import maestrogroup.core.ExceptionHandler.BaseException;
 import maestrogroup.core.ExceptionHandler.BaseResponse;
 import maestrogroup.core.Security.JwtService;
@@ -14,6 +16,7 @@ import java.util.List;
 
 
 @RequestMapping("/mapping")
+@Api(value = "Mapping", tags = "Mapping 관련 API (User와 Team 간 관계)")
 @RestController
 public class MappingController {
     @Autowired
@@ -41,6 +44,7 @@ public class MappingController {
     // team 객체와 mapping 객체를 생성
     @ResponseBody
     @PostMapping("/makeTeam")
+    @Operation(summary = "팀 생성", description = "jwt 를 HttpHeader에 넘겨주시고 생성해주세요. 누락된 정보가 있거나 20글자를 초과할 때 에러를 발생시켰습니다.")
     public BaseResponse makeTeam(@RequestBody PostTeamReq postTeamReq) {
         try {
             int userIdxByJwt = jwtService.getUserIdx();
@@ -62,6 +66,7 @@ public class MappingController {
 
     // 이전에 생성된 팀원 그룹에 특정 유저를 초대하기 : mapping 객체만 생성함
     @PostMapping("/inviteUser/{teamIdx}/{userIdx}")
+    @Operation(summary = "상대방을 팀으로 초대", description = "유저 인덱스가 userIdx인 상대방을 팀 인덱스가 teamIdx인 팀으로 초대합니다.")
     public BaseResponse inviteUser(@PathVariable("teamIdx") int teamIdx, @PathVariable("userIdx") int userIdx) {
         try {
             mappingService.inviteUser(teamIdx, userIdx);
@@ -74,6 +79,7 @@ public class MappingController {
 
     // 팀 삭제 => 팀 객체, 해당 팀의 모든 유저들에 대한 Mapping 객체들이 모두 삭제되도록 구현
     @DeleteMapping("/deleteTeam/{teamIdx}")
+    @Operation(summary = "팀 삭제")
     public BaseResponse deleteTeam(@PathVariable("teamIdx") int teamIdx){
         try{
             mappingService.deleteTeam(teamIdx);
@@ -87,6 +93,7 @@ public class MappingController {
     // => 해당 유저에 대한 Mapping 객체가 삭제되도록 구현
     // 또한 해당 팀의 총 인워수가 0이 되는 경우라면, 해당 팀 객체 또한 삭제되도록 구현
     @DeleteMapping("/getOutOfTeam/{teamIdx}")
+    @Operation(summary = "팀 탈퇴", description = "jwt 를 HttpHeader에 넘겨주시고 수행해주세요. 탈퇴를 시도하는 User가 해당 팀에 가입되어 있지 않았을 때 에러를 발생시켰습니다.")
     public BaseResponse getOutOfTeam(@PathVariable("teamIdx") int teamIdx)  throws BaseException{
         try {
             int userIdxByJwt = jwtService.getUserIdx();
@@ -99,6 +106,7 @@ public class MappingController {
 
     // 특정 팀 그룹에 속하는 모든 팀멤버 출력 : ManyToMany
     @GetMapping("/getTeamMembers/{teamIdx}")
+    @Operation(summary = "팀에 속한 팀원들 조회")
     public BaseResponse<List<GetUser>> getTeamMembers(@PathVariable("teamIdx") int teamIdx){
         try {
             List<GetUser> getUserList = mappingProvider.getTeamMembers(teamIdx);
@@ -108,19 +116,20 @@ public class MappingController {
         }
     }
 
-    // 특정 유저가 속해있는 모든 팀 그룹 출력 : ManyToMany
-    @GetMapping("/getTeamList")
-    public BaseResponse<List<GetTeamRes>> getTeamList() throws BaseException{
-        try {
-            int userIdxByJwt = jwtService.getUserIdx();
-            List<GetTeamRes> getTeamResList = mappingProvider.getTeamList(userIdxByJwt);
-            return new BaseResponse<List<GetTeamRes>>(getTeamResList);
-        } catch(BaseException baseException){
-            return new BaseResponse(baseException.getStatus());
-        }
-    }
+//    // 특정 유저가 속해있는 모든 팀 그룹 출력 : ManyToMany
+//    @GetMapping("/getTeamList")
+//    public BaseResponse<List<GetTeamRes>> getTeamList() throws BaseException{
+//        try {
+//            int userIdxByJwt = jwtService.getUserIdx();
+//            List<GetTeamRes> getTeamResList = mappingProvider.getTeamList(userIdxByJwt);
+//            return new BaseResponse<List<GetTeamRes>>(getTeamResList);
+//        } catch(BaseException baseException){
+//            return new BaseResponse(baseException.getStatus());
+//        }
+//    }
 
     @PatchMapping("/changeImportanceOfTeam/{teamIdx}")
+    @Operation(summary = "팀 별 표시 기능", description = "jwt 를 HttpHeader에 넘겨주시고 수행해주세요. 팀의 중요도를 나타내는 별 표시 기능입니다. important가 0이라면 1이 되고, 1이라면 0이 되도록 구현했습니다. 별 표시를 시도하는 User가 해당 팀에 가입되어 있지 않았을 때 에러를 발생시켰습니다.")
     public BaseResponse changeImportanceOfTeam(@PathVariable("teamIdx") int teamIdx) throws BaseException {
         try {
             int userIdx = jwtService.getUserIdx();
@@ -131,7 +140,9 @@ public class MappingController {
         }
     }
 
-    @GetMapping("/getTeamListAndImportant")
+//    @GetMapping("/getTeamListAndImportant")
+    @GetMapping("/getTeamList")
+    @Operation(summary = "본인이 속한 팀 목록 조회", description = "jwt 를 HttpHeader에 넘겨주시고 수행해주세요. 현재 User가 속한 팀의 목록 및 정보들을 조회합니다.")
     public BaseResponse<List<GetTeamAndImportantRes>> getTeamListAndImportant() throws BaseException{
         try {
             int userIdx = jwtService.getUserIdx();

--- a/src/main/java/maestrogroup/core/mapping/model/GetTeamAndImportantRes.java
+++ b/src/main/java/maestrogroup/core/mapping/model/GetTeamAndImportantRes.java
@@ -1,5 +1,6 @@
 package maestrogroup.core.mapping.model;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,8 +9,15 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class GetTeamAndImportantRes {
+    @ApiModelProperty(example = "4")
     private int teamIdx;
+
+    @ApiModelProperty(example = "멋쟁이 사자처럼 밴드")
     private String teamName;
+
+    @ApiModelProperty(example = "7")
     private int count;
+
+    @ApiModelProperty(example = "0")
     private int important;
 }

--- a/src/main/java/maestrogroup/core/mapping/model/GetTeamIdx.java
+++ b/src/main/java/maestrogroup/core/mapping/model/GetTeamIdx.java
@@ -1,5 +1,6 @@
 package maestrogroup.core.mapping.model;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,5 +9,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class GetTeamIdx {
+    @ApiModelProperty(example = "1")
     int teamIdx;
 }

--- a/src/main/java/maestrogroup/core/mapping/model/GetUserIdx.java
+++ b/src/main/java/maestrogroup/core/mapping/model/GetUserIdx.java
@@ -1,5 +1,6 @@
 package maestrogroup.core.mapping.model;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,5 +9,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class GetUserIdx {
+    @ApiModelProperty(example = "4")
     int userIdx;
 }

--- a/src/main/java/maestrogroup/core/mapping/model/Mapping.java
+++ b/src/main/java/maestrogroup/core/mapping/model/Mapping.java
@@ -1,5 +1,6 @@
 package maestrogroup.core.mapping.model;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,8 +9,15 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class Mapping {
+    @ApiModelProperty(example = "1")
     int mappingIdx;
+
+    @ApiModelProperty(example = "0")
     int important;
+
+    @ApiModelProperty(example = "1")
     int teamIdx;
+
+    @ApiModelProperty(example = "4")
     int userIdx;
 }

--- a/src/main/java/maestrogroup/core/music/MusicController.java
+++ b/src/main/java/maestrogroup/core/music/MusicController.java
@@ -1,5 +1,7 @@
 package maestrogroup.core.music;
 
+import io.swagger.annotations.Api;
+import io.swagger.v3.oas.annotations.Operation;
 import maestrogroup.core.ExceptionHandler.BaseException;
 import maestrogroup.core.ExceptionHandler.BaseResponse;
 import maestrogroup.core.music.model.Music;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RequestMapping(value = "/music")
+@Api(value = "Music", tags = "Music 관련 API")
 @RestController
 public class MusicController {
 
@@ -28,6 +31,7 @@ public class MusicController {
     }
 
     @GetMapping("getMusicList/{folderIdx}")
+    @Operation(summary = "특정 폴더 내 음악들의 정보 불러오기", description = "")
     public BaseResponse<List<Music>> GetAllMusic(@PathVariable("folderIdx") int folderIdx){
         try {
             List<Music> musicList = musicProvider.GetAllMusic(folderIdx);
@@ -39,6 +43,7 @@ public class MusicController {
 
     @ResponseBody
     @PostMapping("createMusic/{folderIdx}")
+    @Operation(summary = "음악 생성", description = "음악 이름, BPM, 애니메이션에 필요한 동그라미의 개수를 입력해주세요. 누락된 정보가 있거나 BPM, 동그라미 개수가 0보다 같거나 작을 때 에러를 발생시켰습니다.")
     public BaseResponse createMusic (@RequestBody PostMusicReq postMusicReq, @PathVariable int folderIdx) {
         try {
             musicService.createMusic(postMusicReq, folderIdx);
@@ -49,6 +54,7 @@ public class MusicController {
     }
 
     @GetMapping("getMusicInfo/{musicIdx}")
+    @Operation(summary = "음악 정보 조회", description = "음악의 기본적인 정보와 더불어, 메트로놈 애니메이션에 필요한 정보들을 제공합니다.")
     public BaseResponse<MusicInfoRes> GetAllMusicInfo(@PathVariable("musicIdx") int musicIdx){
         try {
             MusicInfoRes musicInfo = musicProvider.GetMusicInfo(musicIdx);
@@ -60,6 +66,7 @@ public class MusicController {
 
     @ResponseBody
     @PatchMapping("modifyMusic/{musicIdx}")
+    @Operation(summary = "음악 정보 수정", description = "음악 정보를 수정합니다. 누락된 정보가 있거나 BPM, 동그라미 개수가 0보다 같거나 작을 때 에러를 발생시켰습니다.")
     public BaseResponse modifyMusic(@RequestBody PostMusicReq postMusicReq, @PathVariable("musicIdx") int musicIdx) {
         try {
             musicService.modifyMusic(postMusicReq, musicIdx);
@@ -70,6 +77,7 @@ public class MusicController {
     }
 
     @DeleteMapping("deleteMusic/{musicIdx}")
+    @Operation(summary = "음악 삭제")
     public BaseResponse deleteMusic(@PathVariable("musicIdx") int musicIdx) {
         try {
             musicService.deleteMusic(musicIdx);

--- a/src/main/java/maestrogroup/core/music/model/Music.java
+++ b/src/main/java/maestrogroup/core/music/model/Music.java
@@ -1,5 +1,6 @@
 package maestrogroup.core.music.model;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,11 +9,22 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class Music {
+    @ApiModelProperty(example = "1")
     int musicIdx;
+
+    @ApiModelProperty(example = "80")
     int bpm;
+
+    @ApiModelProperty(example = "4")
     int folderIdx;
+
+    @ApiModelProperty(example = "Ditto")
     String musicName;
+
+    @ApiModelProperty(example = "4")
     int circleNum;
+
+    @ApiModelProperty(example = "3.0")
     double totalNum;
 
 

--- a/src/main/java/maestrogroup/core/music/model/MusicInfoRes.java
+++ b/src/main/java/maestrogroup/core/music/model/MusicInfoRes.java
@@ -1,5 +1,6 @@
 package maestrogroup.core.music.model;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,11 +12,29 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class MusicInfoRes {
+    @ApiModelProperty(example = "1")
     int musicIdx;
+
+    @ApiModelProperty(example = "80")
     int bpm;
+
+    @ApiModelProperty(example = "4")
     int folderIdx;
+
+    @ApiModelProperty(example = "Ditto")
     String musicName;
+
+    @ApiModelProperty(example = "4")
     int circleNum;
+
+    @ApiModelProperty(example = "3.0")
     double totalNum;
+
+    @ApiModelProperty(example = "[" +
+            "0.0," +
+            "0.75," +
+            "1.5," +
+            "2.25" +
+            "]")
     List<Double> startTimes;
 }

--- a/src/main/java/maestrogroup/core/music/model/PostMusicReq.java
+++ b/src/main/java/maestrogroup/core/music/model/PostMusicReq.java
@@ -1,5 +1,6 @@
 package maestrogroup.core.music.model;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,7 +9,12 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class PostMusicReq {
+    @ApiModelProperty(example = "Ditto")
     private String musicName;
+
+    @ApiModelProperty(example = "80")
     private int bpm;
+
+    @ApiModelProperty(example = "4")
     private int circleNum;
 }

--- a/src/main/java/maestrogroup/core/team/TeamContoller.java
+++ b/src/main/java/maestrogroup/core/team/TeamContoller.java
@@ -62,18 +62,18 @@ public class TeamContoller {
         }
     }
 
-    @ResponseBody
-    @DeleteMapping("/delete_team/{teamIdx}")
-    @Operation(summary = "팀 삭제", description = "jwt 를 HttpHeader에 넘겨주시고 삭제해주세요. 수정을 시도하는 User가 해당 팀원이 아닐 경우 에러를 발생시킵니다.")
-    public BaseResponse deleteTeam(@PathVariable("teamIdx") int teamIdx){
-        try {
-            int userIdx = jwtService.getUserIdx();
-            teamService.deleteTeam(teamIdx, userIdx);
-            return new BaseResponse();
-        } catch (BaseException baseException) {
-            return new BaseResponse(baseException.getStatus());
-        }
-    }
+//    @ResponseBody
+//    @DeleteMapping("/delete_team/{teamIdx}")
+//    @Operation(summary = "팀 삭제", description = "jwt 를 HttpHeader에 넘겨주시고 삭제해주세요. 수정을 시도하는 User가 해당 팀원이 아닐 경우 에러를 발생시킵니다.")
+//    public BaseResponse deleteTeam(@PathVariable("teamIdx") int teamIdx){
+//        try {
+//            int userIdx = jwtService.getUserIdx();
+//            teamService.deleteTeam(teamIdx, userIdx);
+//            return new BaseResponse();
+//        } catch (BaseException baseException) {
+//            return new BaseResponse(baseException.getStatus());
+//        }
+//    }
 
 //    @ResponseBody
 //    @PatchMapping("/change_team_leader/{teamIdx}/{userIdx1}/{userIdx2}")

--- a/src/main/java/maestrogroup/core/team/TeamContoller.java
+++ b/src/main/java/maestrogroup/core/team/TeamContoller.java
@@ -1,5 +1,7 @@
 package maestrogroup.core.team;
 
+import io.swagger.annotations.Api;
+import io.swagger.v3.oas.annotations.Operation;
 import maestrogroup.core.ExceptionHandler.BaseException;
 import maestrogroup.core.ExceptionHandler.BaseResponse;
 import maestrogroup.core.Security.JwtService;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
+@Api(value = "Team", tags = "Team 관련 API")
 public class TeamContoller {
     @Autowired // 의존관계 주입
     private final TeamDao teamDao;
@@ -29,16 +32,17 @@ public class TeamContoller {
         this.jwtService = jwtService;
     }
 
-    @ResponseBody
-    @PostMapping("/create_team")
-    public void createTeam(@RequestBody PostTeamReq postTeamReq){
-        teamService.createTeam(postTeamReq);
-        //PostTeamRes postTeamRes = teamService.createTeam(postTeamReq);
-        //return postTeamRes;
-    }
+//    @ResponseBody
+//    @PostMapping("/create_team")
+//    public void createTeam(@RequestBody PostTeamReq postTeamReq){
+//        teamService.createTeam(postTeamReq);
+//        //PostTeamRes postTeamRes = teamService.createTeam(postTeamReq);
+//        //return postTeamRes;
+//    }
 
     @ResponseBody
     @GetMapping("/get_all_team")
+    @Operation(summary = "모든 팀의 정보 조회 (테스트 전용)", description = "서비스 내 모든 팀의 정보를 조회합니다. 단순 테스트 용이니 참고 바랍니다.")
     public List<GetTeamRes> getAllTeam(){
         List<GetTeamRes> getTeamResList = teamProvider.getAllTeam();
         return getTeamResList;
@@ -46,6 +50,7 @@ public class TeamContoller {
 
     @ResponseBody
     @PatchMapping("/patch_team/{teamIdx}")
+    @Operation(summary = "팀 정보 수정", description = "jwt 를 HttpHeader에 넘겨주시고 수정해주세요. 수정을 시도하는 User가 해당 팀원이 아닐 경우 에러를 발생시킵니다. 입력이 누락된 데이터가 있을 시 에러를 발생시킵니다.")
     public BaseResponse modifyTeam(@PathVariable("teamIdx") int teamIdx, @RequestBody PostTeamReq postTeamReq){
         try {
             int userIdx = jwtService.getUserIdx();
@@ -59,6 +64,7 @@ public class TeamContoller {
 
     @ResponseBody
     @DeleteMapping("/delete_team/{teamIdx}")
+    @Operation(summary = "팀 삭제", description = "jwt 를 HttpHeader에 넘겨주시고 삭제해주세요. 수정을 시도하는 User가 해당 팀원이 아닐 경우 에러를 발생시킵니다.")
     public BaseResponse deleteTeam(@PathVariable("teamIdx") int teamIdx){
         try {
             int userIdx = jwtService.getUserIdx();
@@ -69,11 +75,11 @@ public class TeamContoller {
         }
     }
 
-    @ResponseBody
-    @PatchMapping("/change_team_leader/{teamIdx}/{userIdx1}/{userIdx2}")
-    public void modifyTeamLeader(@PathVariable("teamIdx")  int teamIdx, @PathVariable("userIdx1") int userIdx1, @PathVariable("userIdx2") int userIdx2) throws BaseException {
-        teamService.modifyTeamLeader(userIdx1, userIdx2, teamIdx);
-    }
+//    @ResponseBody
+//    @PatchMapping("/change_team_leader/{teamIdx}/{userIdx1}/{userIdx2}")
+//    public void modifyTeamLeader(@PathVariable("teamIdx")  int teamIdx, @PathVariable("userIdx1") int userIdx1, @PathVariable("userIdx2") int userIdx2) throws BaseException {
+//        teamService.modifyTeamLeader(userIdx1, userIdx2, teamIdx);
+//    }
 }
 
 

--- a/src/main/java/maestrogroup/core/team/model/GetTeamRes.java
+++ b/src/main/java/maestrogroup/core/team/model/GetTeamRes.java
@@ -1,5 +1,6 @@
 package maestrogroup.core.team.model;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,8 +9,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class GetTeamRes {
+    @ApiModelProperty(example = "1")
     private int teamIdx;
+
+    @ApiModelProperty(example = "멋쟁이 사자처럼 밴드")
     private String teamName;
+
+    @ApiModelProperty(example = "7")
     private int count;
 
 //    public GetTeamRes(int teamIdx, String teamName, String teamImgUrl, int count, int leaderIdx) {

--- a/src/main/java/maestrogroup/core/team/model/PatchTeamReq.java
+++ b/src/main/java/maestrogroup/core/team/model/PatchTeamReq.java
@@ -1,10 +1,14 @@
 package maestrogroup.core.team.model;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
 @Data
 public class PatchTeamReq {
+    @ApiModelProperty(example = "1")
     private int teamIdx;
+
+    @ApiModelProperty(example = "멋쟁이 사자처럼 밴드2")
     private String teamName;
 
     public PatchTeamReq(int teamIdx, String teamName) {

--- a/src/main/java/maestrogroup/core/team/model/PostTeamReq.java
+++ b/src/main/java/maestrogroup/core/team/model/PostTeamReq.java
@@ -1,5 +1,6 @@
 package maestrogroup.core.team.model;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,5 +9,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class PostTeamReq {
+    @ApiModelProperty(example = "멋쟁이 사자처럼 밴드")
     private String teamName;
 }

--- a/src/main/java/maestrogroup/core/team/model/PostTeamRes.java
+++ b/src/main/java/maestrogroup/core/team/model/PostTeamRes.java
@@ -1,12 +1,19 @@
 package maestrogroup.core.team.model;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
 
 @Data
 public class PostTeamRes {
+    @ApiModelProperty(example = "1")
     private int teamIdx;
+
+    @ApiModelProperty(example = "멋쟁이 사자처럼 밴드")
     private String teamName;
+
+    @ApiModelProperty(example = "1")
     private int count;
 
     public PostTeamRes(int teamIdx, String teamName, String teamImgUrl, int count) {

--- a/src/main/java/maestrogroup/core/user/UserController.java
+++ b/src/main/java/maestrogroup/core/user/UserController.java
@@ -2,6 +2,8 @@ package maestrogroup.core.user;
 
 
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.v3.oas.annotations.Operation;
 import maestrogroup.core.ExceptionHandler.BaseException;
 import maestrogroup.core.ExceptionHandler.BaseResponse;
@@ -116,6 +118,7 @@ public class UserController {
 
     @ResponseBody
     @GetMapping("/getUser")
+    @Operation(summary = "회원정보(프로필) 조회", description = "jwt 를 HttpHeader에 넘겨주시고 조회해주세요. 마이페이지에 쓰이는 기능입니다.")
     public BaseResponse<GetUser> getUser(){
         try {
             int userIdx = jwtService.getUserIdx();

--- a/src/main/java/maestrogroup/core/user/model/GetUser.java
+++ b/src/main/java/maestrogroup/core/user/model/GetUser.java
@@ -1,6 +1,7 @@
 package maestrogroup.core.user.model;
 
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -9,8 +10,15 @@ import java.sql.Timestamp;
 @Data
 @AllArgsConstructor
 public class GetUser {
+    @ApiModelProperty(example = "3")
     private int userIdx;
+
+    @ApiModelProperty(example = "abced3@naver.com")
     private String email;
+
+    @ApiModelProperty(example = "member3")
     private String nickname;
+
+    @ApiModelProperty(example = "COMIBCntXT+usiVZO7dtAw==")
     private String password;
 }

--- a/src/main/java/maestrogroup/core/user/model/LoginUserReq.java
+++ b/src/main/java/maestrogroup/core/user/model/LoginUserReq.java
@@ -1,5 +1,6 @@
 package maestrogroup.core.user.model;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,7 +9,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class LoginUserReq {
+    @ApiModelProperty(example = "abcde2@naver.com")
     private String email;
+
+    @ApiModelProperty(example = "abcde1234")
     private String password;
 }
 

--- a/src/main/java/maestrogroup/core/user/model/LoginUserRes.java
+++ b/src/main/java/maestrogroup/core/user/model/LoginUserRes.java
@@ -1,14 +1,24 @@
 package maestrogroup.core.user.model;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
 @AllArgsConstructor
 public class LoginUserRes {
+    @ApiModelProperty(example = "2")
     private int userIdx;
+
+    @ApiModelProperty(example = "abcde2@naver.com")
     private String email;
+
+    @ApiModelProperty(example = "member2")
     private String nickname;
+
+    @ApiModelProperty(example = "eyJ0eXBlIjoiand0IiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VySWR4IjoyLCJpYXQiOjE2NzI1ODY1MjgsImV4cCI6MTY3MjU4ODMyOH0.9jucKLYE3m1WTvkYdKuvOoo0zN3guDcStuvJWg18lWc")
     private String accessToken; // 로그인에 성공하면 jwt 토큰값도 리턴
+
+    @ApiModelProperty(example = "eyJ0eXBlIjoiand0IiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VySWR4IjoyLCJpYXQiOjE2NzI1ODY1MjgsImV4cCI6MTY3MzE5MTMyOH0.-Xb5pLfdNE7nVxYu6MQRJzsPAyBNMKv382WrERTLJgw")
     private String refreshToken;
 }

--- a/src/main/java/maestrogroup/core/user/model/ModifyUserInfoReq.java
+++ b/src/main/java/maestrogroup/core/user/model/ModifyUserInfoReq.java
@@ -1,4 +1,5 @@
 package maestrogroup.core.user.model;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,7 +9,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ModifyUserInfoReq {
+    @ApiModelProperty(example = "ABCDE2@naver.com")
     private String email;
+
+    @ApiModelProperty(example = "MEMBER2")
     private String nickname;
+
+    @ApiModelProperty(example = "edcba4321")
     private String password;
 }

--- a/src/main/java/maestrogroup/core/user/model/SignUpUserReq.java
+++ b/src/main/java/maestrogroup/core/user/model/SignUpUserReq.java
@@ -1,5 +1,6 @@
 package maestrogroup.core.user.model;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
 
 import javax.validation.constraints.Email;
@@ -12,9 +13,16 @@ import javax.validation.constraints.Pattern;
 @NoArgsConstructor
 public class SignUpUserReq {
     //@Email(message = "올바른 이메일 형식이 아닙니다.")
+    @ApiModelProperty(example = "abcde2@naver.com")
     private String email;
+
+    @ApiModelProperty(example = "abcde12345")
     private String password;
+
+    @ApiModelProperty(example = "abcde12345")
     private String repass;
+
+    @ApiModelProperty(example = "member2")
     private String nickname;
     
 }

--- a/src/main/java/maestrogroup/core/user/model/SignUpUserRes.java
+++ b/src/main/java/maestrogroup/core/user/model/SignUpUserRes.java
@@ -1,5 +1,6 @@
 package maestrogroup.core.user.model;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,8 +9,15 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class SignUpUserRes {
+    @ApiModelProperty(example = "3")
     private int userIdx;
+
+    @ApiModelProperty(example = "abcde3@naver.com")
     private String email;
+
+    @ApiModelProperty(example = "COMIBCntXT+usiVZO7dtAw==")
     private String password;
+
+    @ApiModelProperty(example = "member3")
     private String nickname;
 }


### PR DESCRIPTION
1. Swagger를 통해 API 명세서를 작성하였습니다.
2. Swagger config의 내용을 수정하여 Swagger 페이지에서도 jwt를 적용할 수 있도록 하였습니다.
3. 겹치거나 사용하지 않는 API의 경우 주석처리를 하여 Swagger 페이지에 노출되지 않도록 하였습니다.
4. `@Operation`을 통해 API의 설명을 작성하였습니다.
5. `@ApiModelProperty`를 통해 Request 와 Response의 예시 값을 작성하였습니다.
---
## Swagger 페이지 내에서 jwt 적용하는 방법
### 적용 조건
- DB에 생성한 User 정보가 필요합니다. (signUp 필요)

### 적용 과정
![스크린샷 2023-01-02 오전 1 06 52](https://user-images.githubusercontent.com/96401830/210177454-8759eea6-9f74-42f6-9dfc-c813366903bc.png)
Swagger 페이지 내 로그인 기능을 찾고, Try it out 버튼을 클릭합니다.

![스크린샷 2023-01-02 오전 1 07 35](https://user-images.githubusercontent.com/96401830/210177474-1767d605-1ea4-46e4-a935-15d1810b3dfb.png)
이미 생성한 User 정보를 기입하여 로그인합니다.

![스크린샷 2023-01-02 오전 1 07 58](https://user-images.githubusercontent.com/96401830/210177487-616d7c55-385f-4fb1-b720-40db6bbf224f.png)
위 과정 이후 Response 부분에서 "accessToken" 의 값을 복사합니다.

![스크린샷 2023-01-02 오전 1 08 49](https://user-images.githubusercontent.com/96401830/210177503-4070f66a-133e-4774-a24c-7912c01e8699.png)
Swagger 페이지 상단으로 올라와 Authorize 버튼을 클릭합니다.

![스크린샷 2023-01-02 오전 1 09 18](https://user-images.githubusercontent.com/96401830/210177515-335630d4-1414-4b9f-b92a-bc2279cca8e2.png)
앞서 복사한 accessToken 값을 붙여넣기 하고, Authorize 버튼을 누릅니다. 위 과정을 마치면 로그인 상태가 됩니다.