### PR TITLE
feat: 개인 메트로놈 페이지에 필요한 정보 조회 기능 추가

### DIFF
--- a/src/main/java/maestrogroup/core/music/MusicController.java
+++ b/src/main/java/maestrogroup/core/music/MusicController.java
@@ -85,15 +85,27 @@ public class MusicController {
         }
     }
 
-    @PostMapping("")
-    @Operation(summary = "개인 메트로놈 페이지에 필요한 정보 조회", description = "BPM, 동그라미 개수가 0보다 같거나 작을 때 에러를 발생시켰습니다.")
-    public BaseResponse<SelfMusicRes> getSelfMusicInfo(@RequestBody SelfMusicReq selfMusicReq) {
+    @PostMapping("/self")
+    @Operation(summary = "Requestbody를 이용한 개인 메트로놈 페이지에 필요한 정보 조회", description = "BPM, 동그라미 개수가 0보다 같거나 작을 때 에러를 발생시켰습니다.")
+    public BaseResponse<SelfMusicRes> getSelfMusicInfoWithBody(@RequestBody SelfMusicReq selfMusicReq) {
         try {
-            SelfMusicRes selfMusicInfo = musicProvider.getSelfMusicInfo(selfMusicReq);
+            int bpm = selfMusicReq.getBpm();
+            int circleNum = selfMusicReq.getCircleNum();
+            SelfMusicRes selfMusicInfo = musicProvider.getSelfMusicInfo(bpm, circleNum);
             return new BaseResponse(selfMusicInfo);
         } catch (BaseException baseException) {
             return new BaseResponse<>(baseException.getStatus());
         }
+    }
 
+    @GetMapping("/self/{bpm}/{circleNum}")
+    @Operation(summary = "Pathvariable을 이용한 개인 메트로놈 페이지에 필요한 정보 조회", description = "BPM, 동그라미 개수가 0보다 같거나 작을 때 에러를 발생시켰습니다.")
+    public BaseResponse<SelfMusicRes> getSelfMusicInfoWithBody(@PathVariable("bpm") int bpm, @PathVariable("circleNum") int circleNum) {
+        try {
+            SelfMusicRes selfMusicInfo = musicProvider.getSelfMusicInfo(bpm, circleNum);
+            return new BaseResponse(selfMusicInfo);
+        } catch (BaseException baseException) {
+            return new BaseResponse<>(baseException.getStatus());
+        }
     }
 }

--- a/src/main/java/maestrogroup/core/music/MusicController.java
+++ b/src/main/java/maestrogroup/core/music/MusicController.java
@@ -4,9 +4,7 @@ import io.swagger.annotations.Api;
 import io.swagger.v3.oas.annotations.Operation;
 import maestrogroup.core.ExceptionHandler.BaseException;
 import maestrogroup.core.ExceptionHandler.BaseResponse;
-import maestrogroup.core.music.model.Music;
-import maestrogroup.core.music.model.MusicInfoRes;
-import maestrogroup.core.music.model.PostMusicReq;
+import maestrogroup.core.music.model.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -85,5 +83,17 @@ public class MusicController {
         } catch (BaseException baseException) {
             return new BaseResponse(baseException.getStatus());
         }
+    }
+
+    @PostMapping("")
+    @Operation(summary = "개인 메트로놈 페이지에 필요한 정보 조회", description = "BPM, 동그라미 개수가 0보다 같거나 작을 때 에러를 발생시켰습니다.")
+    public BaseResponse<SelfMusicRes> getSelfMusicInfo(@RequestBody SelfMusicReq selfMusicReq) {
+        try {
+            SelfMusicRes selfMusicInfo = musicProvider.getSelfMusicInfo(selfMusicReq);
+            return new BaseResponse(selfMusicInfo);
+        } catch (BaseException baseException) {
+            return new BaseResponse<>(baseException.getStatus());
+        }
+
     }
 }

--- a/src/main/java/maestrogroup/core/music/MusicDao.java
+++ b/src/main/java/maestrogroup/core/music/MusicDao.java
@@ -2,9 +2,7 @@ package maestrogroup.core.music;
 
 import maestrogroup.core.ExceptionHandler.BaseException;
 import maestrogroup.core.ExceptionHandler.BaseResponseStatus;
-import maestrogroup.core.music.model.Music;
-import maestrogroup.core.music.model.MusicInfoRes;
-import maestrogroup.core.music.model.PostMusicReq;
+import maestrogroup.core.music.model.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -96,6 +94,22 @@ public class MusicDao {
         } catch (Exception e){
             throw new BaseException(BaseResponseStatus.SERVER_ERROR);
         }
+    }
+
+    public SelfMusicRes getSelfMusicInfo(SelfMusicReq selfMusicReq) {
+        int bpm = selfMusicReq.getBpm();
+        int circleNum = selfMusicReq.getCircleNum();
+        double waitTime = (double) 60 / bpm;
+
+        double totalNum = waitTime * circleNum;
+        double num = 0;
+        List<Double> startTimes = new ArrayList<>();
+        for (int i = 0; i < circleNum; i++) {
+            startTimes.add(num);
+            num += waitTime;
+        }
+
+        return new SelfMusicRes(totalNum, startTimes);
     }
 
     public int checkMusicNameLength(String musicName){

--- a/src/main/java/maestrogroup/core/music/MusicDao.java
+++ b/src/main/java/maestrogroup/core/music/MusicDao.java
@@ -96,9 +96,7 @@ public class MusicDao {
         }
     }
 
-    public SelfMusicRes getSelfMusicInfo(SelfMusicReq selfMusicReq) {
-        int bpm = selfMusicReq.getBpm();
-        int circleNum = selfMusicReq.getCircleNum();
+    public SelfMusicRes getSelfMusicInfo(int bpm, int circleNum) {
         double waitTime = (double) 60 / bpm;
 
         double totalNum = waitTime * circleNum;

--- a/src/main/java/maestrogroup/core/music/MusicProvider.java
+++ b/src/main/java/maestrogroup/core/music/MusicProvider.java
@@ -46,15 +46,15 @@ public class MusicProvider {
         return musicDao.GetMusicInfo(musicIdx);
     }
 
-    public SelfMusicRes getSelfMusicInfo(SelfMusicReq selfMusicReq) throws BaseException {
-        if (selfMusicReq.getBpm() <= 0) {
+    public SelfMusicRes getSelfMusicInfo(int bpm, int circleNum) throws BaseException {
+        if (bpm <= 0) {
             throw new BaseException(BaseResponseStatus.INVALID_MUSIC_VALUE);
         }
 
-        if (selfMusicReq.getCircleNum() <= 0) {
+        if (circleNum <= 0) {
             throw new BaseException(BaseResponseStatus.INVALID_MUSIC_VALUE);
         }
 
-        return musicDao.getSelfMusicInfo(selfMusicReq);
+        return musicDao.getSelfMusicInfo(bpm, circleNum);
     }
 }

--- a/src/main/java/maestrogroup/core/music/MusicProvider.java
+++ b/src/main/java/maestrogroup/core/music/MusicProvider.java
@@ -5,6 +5,8 @@ import maestrogroup.core.ExceptionHandler.BaseResponseStatus;
 import maestrogroup.core.folder.FolderDao;
 import maestrogroup.core.music.model.Music;
 import maestrogroup.core.music.model.MusicInfoRes;
+import maestrogroup.core.music.model.SelfMusicReq;
+import maestrogroup.core.music.model.SelfMusicRes;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -42,5 +44,17 @@ public class MusicProvider {
             throw new BaseException(BaseResponseStatus.NOT_EXISTS_MUSIC);
         }
         return musicDao.GetMusicInfo(musicIdx);
+    }
+
+    public SelfMusicRes getSelfMusicInfo(SelfMusicReq selfMusicReq) throws BaseException {
+        if (selfMusicReq.getBpm() <= 0) {
+            throw new BaseException(BaseResponseStatus.INVALID_MUSIC_VALUE);
+        }
+
+        if (selfMusicReq.getCircleNum() <= 0) {
+            throw new BaseException(BaseResponseStatus.INVALID_MUSIC_VALUE);
+        }
+
+        return musicDao.getSelfMusicInfo(selfMusicReq);
     }
 }

--- a/src/main/java/maestrogroup/core/music/model/SelfMusicReq.java
+++ b/src/main/java/maestrogroup/core/music/model/SelfMusicReq.java
@@ -1,0 +1,17 @@
+package maestrogroup.core.music.model;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SelfMusicReq {
+    @ApiModelProperty(example = "80")
+    private int bpm;
+
+    @ApiModelProperty(example = "4")
+    private int circleNum;
+}

--- a/src/main/java/maestrogroup/core/music/model/SelfMusicRes.java
+++ b/src/main/java/maestrogroup/core/music/model/SelfMusicRes.java
@@ -1,0 +1,24 @@
+package maestrogroup.core.music.model;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SelfMusicRes {
+    @ApiModelProperty(example = "3.0")
+    double totalNum;
+
+    @ApiModelProperty(example = "[" +
+            "0.0," +
+            "0.75," +
+            "1.5," +
+            "2.25" +
+            "]")
+    List<Double> startTimes;
+}


### PR DESCRIPTION
### 추가 내용
- 합주가 아닌 개인 메트로놈 페이지 동작에 필요한 정보를 조회하는 기능을 추가했습니다.
- 박자 정보를 Requestbody로 입력하면 페이지 내 애니메이션 동작에 필요한 정보들을 알려줍니다.
- 박자 정보를 Pathvariable로 입력하면 페이지 내 애니메이션 동작에 필요한 정보들을 알려줍니다.

### 두 가지 방식을 모두 개발한 이유
![메트로놈 시작 전](https://user-images.githubusercontent.com/96401830/213350920-7bce1fb2-c67c-4954-9cbf-f2cdb8aa2674.png)

프론트와 회의 때 개인 메트로놈 페이지에 필요한 정보들을 조회하기 위해서 백엔드 쪽에서의 연산이 필요할 수 있다고 전달 받았습니다. 

프론트에서 위와 같이 bpm과 beats를 설정한 후 재생 버튼을 눌렀을 때 백엔드에서 에니메이션 동작에 필요한 정보들을 넘겨주길 바란다고 했습니다.

이때 프론트에서 어떠한 방식으로 bpm과 beats 정보를 전달할지 모를 수 있어 두 가지 경우에 대한 기능을 모두 제작해놓았습니다.

### Requestbody를 통한 입력 방식
url: `/self`
GET이 아닌 POST 방식을 사용한 이유는 다음과 같은 에러를 해결하기 위함입니다.
<img width="643" alt="스크린샷 2023-01-19 오후 12 28 41" src="https://user-images.githubusercontent.com/96401830/213349195-6cd695d2-253f-47c6-8c3b-e773b7880a28.png">

postman에서는 GET요청 시 Request body를 포함하더라도 작동되지만, 일반적으로 GET 메소드는 URL에 특정 리소스를 붙여서 정보를 요청하는 메소드이며, 용량에 한계가 있기 때문에 GET 요청시 Request Body 에 담아서 보내지 않는다고 합니다.
참고: https://velog.io/@pixelstudio/HTTP-Method와-Body 

### Parhvariable을 통한 입력 방식
url: `/self/{bpm}/{circleNum}`
GET 요청 방식으로 일반적인 방식과 동일하게 사용하면 됩니다.